### PR TITLE
fix(ide): signcolumn, clangd extensions, and C/C++ formatting

### DIFF
--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -29,10 +29,11 @@ opt.expandtab = true
 opt.wrap = false
 
 -- Gutter
--- Hide the sign column entirely. Diagnostics are surfaced through
--- virtual text and underlines instead of gutter icons. This reclaims
--- 2-3 columns of horizontal space on every window.
-opt.signcolumn = 'no'
+-- Enable the signcolumn so LSP diagnostics, gitsigns changes, and DAP
+-- breakpoints are visible in the left gutter. Hiding it saves 2 columns
+-- but breaks the IDE experience (you cannot see where errors or breakpoints
+-- live without opening the line). See: https://neovim.io/doc/user/options.html#'signcolumn'
+opt.signcolumn = 'yes:2'
 
 -- Python Tooling
 -- LazyVim reads these globals to decide which LSP and linter to

--- a/lua/plugins/clangd.lua
+++ b/lua/plugins/clangd.lua
@@ -13,22 +13,26 @@ return {
                 only_current_line = false,
             },
             ast = {
+                -- Icons below use standard Unicode (Geometric Shapes / Misc Symbols)
+                -- so they render correctly without a Nerd Font patched terminal font.
+                -- If you prefer Nerd Font icons, install a patched font (e.g. JetBrainsMono Nerd Font)
+                -- and replace these with the original Nerd Font glyphs.
                 role_icons = {
-                    type = "",
-                    declaration = "",
-                    expression = "",
-                    specifier = "",
-                    statement = "",
-                    ["template argument"] = "",
+                    type = "◆",
+                    declaration = "◇",
+                    expression = "●",
+                    specifier = "▸",
+                    statement = "■",
+                    ["template argument"] = "◊",
                 },
                 kind_icons = {
-                    Compound = "",
-                    Recovery = "",
-                    TranslationUnit = "",
-                    PackExpansion = "",
-                    TemplateTypeParm = "",
-                    TemplateTemplateParm = "",
-                    TemplateParamObject = "",
+                    Compound = "◇",
+                    Recovery = "⚠",
+                    TranslationUnit = "◎",
+                    PackExpansion = "⋯",
+                    TemplateTypeParm = "◊",
+                    TemplateTemplateParm = "◊",
+                    TemplateParamObject = "◊",
                 },
             },
         },

--- a/lua/plugins/clangd.lua
+++ b/lua/plugins/clangd.lua
@@ -1,7 +1,36 @@
 ---@type LazyPluginSpec[]
 return {
     {
-        'dchinmay2/clangd_extensions.nvim',
-        lazy = true,
+        -- clangd_extensions.nvim adds extra IDE features on top of the clangd LSP:
+        -- type hierarchy, symbol info, inlay hints, AST view, memory usage, etc.
+        -- It is loaded automatically by LazyVim's `lang.clangd` extra; this spec
+        -- only customizes the default options.
+        -- https://github.com/p00f/clangd_extensions.nvim
+        "p00f/clangd_extensions.nvim",
+        opts = {
+            inlay_hints = {
+                inline = vim.fn.has("nvim-0.10") == 1,
+                only_current_line = false,
+            },
+            ast = {
+                role_icons = {
+                    type = "",
+                    declaration = "",
+                    expression = "",
+                    specifier = "",
+                    statement = "",
+                    ["template argument"] = "",
+                },
+                kind_icons = {
+                    Compound = "",
+                    Recovery = "",
+                    TranslationUnit = "",
+                    PackExpansion = "",
+                    TemplateTypeParm = "",
+                    TemplateTemplateParm = "",
+                    TemplateParamObject = "",
+                },
+            },
+        },
     },
 }

--- a/lua/plugins/fmt_cmake.lua
+++ b/lua/plugins/fmt_cmake.lua
@@ -1,11 +1,24 @@
 ---@type LazyPluginSpec[]
 return {
     {
-        'stevearc/conform.nvim',
+        -- conform.nvim is a lightweight, asynchronous formatter plugin.
+        -- It runs external formatters (e.g. clang-format, cmake_format) in the
+        -- background without blocking the editor, replacing null-ls for formatting.
+        -- https://github.com/stevearc/conform.nvim
+        "stevearc/conform.nvim",
         ---@type conform.setupOpts
         opts = {
             formatters_by_ft = {
-                cmake = { 'cmake_format' },
+                -- cmake_format formats CMakeLists.txt and *.cmake files.
+                -- It reads .cmake-format.py from the repo root when present.
+                -- https://github.com/cheshirekow/cmake_format
+                cmake = { "cmake_format" },
+
+                -- clang-format is the LLVM/Clang project's official C/C++ formatter.
+                -- It uses a .clang-format file in your repo root for style rules.
+                -- https://clang.llvm.org/docs/ClangFormat.html
+                c = { "clang_format" },
+                cpp = { "clang_format" },
             },
         },
     },

--- a/lua/plugins/fmt_cmake.lua
+++ b/lua/plugins/fmt_cmake.lua
@@ -17,8 +17,8 @@ return {
                 -- clang-format is the LLVM/Clang project's official C/C++ formatter.
                 -- It uses a .clang-format file in your repo root for style rules.
                 -- https://clang.llvm.org/docs/ClangFormat.html
-                c = { "clang_format" },
-                cpp = { "clang_format" },
+                c = { "clang-format" },
+                cpp = { "clang-format" },
             },
         },
     },


### PR DESCRIPTION
This PR fixes three gaps that prevent the config from behaving like a top-tier C++ IDE:

### 1. Enable `signcolumn` (`lua/config/options.lua`)
- **Before:** `signcolumn = 'no'` hid all gutter signs.
- **Problem:** LSP diagnostics, gitsigns, and DAP breakpoints become invisible. You lose the "where is the error/breakpoint" at-a-glance information that every IDE provides.
- **Fix:** `signcolumn = 'yes:2'` permanently reserves two columns so text never jumps when signs appear.
- **Link:** [Neovim signcolumn docs](https://neovim.io/doc/user/options.html#'signcolumn')

### 2. Fix `clangd_extensions.nvim` (`lua/plugins/clangd.lua`)
- **Before:** Spec referenced a fork (`dchinmay2/...`) with `lazy = true` and no triggers — the plugin never loaded, so inlay hints and AST view were dead.
- **Fix:** Switch to the official `p00f/clangd_extensions.nvim` (already loaded by `lang.clangd` extra) and provide tuned `opts` for inlay hints and AST icons.
- **Link:** [clangd_extensions.nvim repo](https://github.com/p00f/clangd_extensions.nvim)

### 3. Add C/C++ formatting to conform (`lua/plugins/fmt_cmake.lua`)
- **Before:** Only `cmake_format` was registered; `:Format` and format-on-save did nothing for `.c`/`.cpp` files.
- **Fix:** Add `clang_format` for `c` and `cpp` filetypes alongside the existing `cmake_format`.
- **Links:** [conform.nvim](https://github.com/stevearc/conform.nvim) | [clang-format docs](https://clang.llvm.org/docs/ClangFormat.html) | [cmake_format](https://github.com/cheshirekow/cmake_format)

---

**Not included (intentionally):** DAP adapter setup (`codelldb`) is still manual — that needs a separate plugin spec and Mason install, so it is left for a follow-up if you want debugger integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: Neovim config-only changes that affect editor UX and tooling integration, with minimal chance of breaking core workflows beyond preferences or missing external formatter binaries.
> 
> **Overview**
> Improves the Neovim C/C++ IDE experience by **re-enabling the left gutter** (`signcolumn = 'yes:2'`) so diagnostics, git signs, and breakpoints are visible and the UI doesn’t shift.
> 
> Switches the `clangd_extensions.nvim` plugin spec to the upstream `p00f/clangd_extensions.nvim` and adds explicit `opts` for inlay hints and AST icon rendering.
> 
> Extends `conform.nvim` formatter configuration to run `clang_format` for `c`/`cpp` files (in addition to existing `cmake_format`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35938bbef5100beb9932c507f13e147c4e475461. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->