### PR TITLE
feat(cmake): professional IDE-grade cmake-tools.nvim integration

### DIFF
--- a/lua/plugins/cmake.lua
+++ b/lua/plugins/cmake.lua
@@ -1,30 +1,61 @@
+-- Professional CMake IDE integration via Civitasv/cmake-tools.nvim.
+-- Comparable to vscode-cmake-tools; auto-detects CMake projects and
+-- provides generate, build, preset selection, debug launch and compile
+-- commands auto-linking for clangd.
+--
+-- Refs:
+--   https://github.com/Civitasv/cmake-tools.nvim
+--   https://github.com/Civitasv/cmake-tools.nvim/blob/main/docs/cmake_presets.md
+--   https://github.com/Civitasv/cmake-tools.nvim/blob/main/docs/howto.md
+
+---Detect whether the current cwd or file lives inside a CMake project.
+---@return boolean
+local function is_cmake_project()
+    local markers = { "CMakeLists.txt", "CMakePresets.json" }
+    local paths = { vim.loop.cwd(), vim.fn.expand("%:p:h") }
+    for _, base in ipairs(paths) do
+        local dir = base
+        while dir and dir ~= "/" and dir ~= "" and not dir:match("^%a:[/\\]?$") do
+            for _, marker in ipairs(markers) do
+                local ok, stat = pcall(vim.loop.fs_stat, dir .. "/" .. marker)
+                if ok and stat then
+                    return true
+                end
+            end
+            dir = vim.fn.fnamemodify(dir, ":h")
+        end
+    end
+    return false
+end
+
 ---@type string[][] -- { suffix, command, label }
 local mappings = {
-    { 'g', 'CMakeGenerate', 'Generate' },
-    { 'b', 'CMakeBuild', 'Build' },
-    { 'r', 'CMakeRun', 'Run' },
-    { 'd', 'CMakeDebug', 'Debug' },
-    { 'c', 'CMakeClean', 'Clean' },
-    { 'x', 'CMakeStop', 'Stop' },
-    { 'p', 'CMakeSelectConfigurePreset', 'Configure Preset' },
-    { 'P', 'CMakeSelectBuildPreset', 'Build Preset' },
-    { 't', 'CMakeSelectBuildTarget', 'Build Target' },
-    { 'l', 'CMakeSelectLaunchTarget', 'Launch Target' },
-    { 'v', 'CMakeSelectBuildType', 'Variant' },
-    { 'k', 'CMakeSelectKit', 'Kit' },
-    { 'o', 'CMakeOpen', 'Open Runner' },
-    { 'q', 'CMakeClose', 'Close Runner' },
-    { 's', 'CMakeSettings', 'Settings' },
+    { "g", "CMakeGenerate", "Generate" },
+    { "b", "CMakeBuild", "Build" },
+    { "r", "CMakeRun", "Run" },
+    { "d", "CMakeDebug", "Debug" },
+    { "c", "CMakeClean", "Clean" },
+    { "x", "CMakeStop", "Stop" },
+    { "p", "CMakeSelectConfigurePreset", "Configure Preset" },
+    { "P", "CMakeSelectBuildPreset", "Build Preset" },
+    { "t", "CMakeSelectBuildTarget", "Build Target" },
+    { "l", "CMakeSelectLaunchTarget", "Launch Target" },
+    { "v", "CMakeSelectBuildType", "Variant" },
+    { "k", "CMakeSelectKit", "Kit" },
+    { "o", "CMakeOpen", "Open Runner" },
+    { "q", "CMakeClose", "Close Runner" },
+    { "s", "CMakeSettings", "Settings" },
+    { "T", "CMakeTest", "CTest" },
+    { "f", "CMakeShowTargetFiles", "Target Files" },
 }
 
 ---@type LazyKeysSpec[]
 local keys = vim.iter(mappings)
     :map(function(m)
-        ---@type LazyKeysSpec
         return {
-            '<leader>ck' .. m[1],
-            '<cmd>' .. m[2] .. '<cr>',
-            desc = 'CMake: ' .. m[3],
+            "<leader>ck" .. m[1],
+            "<cmd>" .. m[2] .. "<cr>",
+            desc = "CMake: " .. m[3],
         }
     end)
     :totable()
@@ -32,18 +63,58 @@ local keys = vim.iter(mappings)
 ---@type LazyPluginSpec[]
 return {
     {
-        'Civitasv/cmake-tools.nvim',
+        "Civitasv/cmake-tools.nvim",
+        cond = is_cmake_project,
+        cmd = {
+            "CMakeGenerate",
+            "CMakeBuild",
+            "CMakeRun",
+            "CMakeDebug",
+            "CMakeClean",
+            "CMakeStop",
+            "CMakeSelectConfigurePreset",
+            "CMakeSelectBuildPreset",
+            "CMakeSelectBuildTarget",
+            "CMakeSelectLaunchTarget",
+            "CMakeSelectBuildType",
+            "CMakeSelectKit",
+            "CMakeOpen",
+            "CMakeClose",
+            "CMakeSettings",
+            "CMakeTest",
+            "CMakeShowTargetFiles",
+            "CMakeQuickBuild",
+            "CMakeCopyCompileCommands",
+        },
+        ft = "cmake",
         keys = keys,
-        opts = {},
+        dependencies = { "nvim-lua/plenary.nvim" },
+        opts = {
+            cmake_use_preset = true,
+            cmake_regenerate_on_save = true,
+            cmake_compile_commands_options = {
+                action = "soft_link",
+                target = vim.loop.cwd,
+            },
+            cmake_virtual_text_support = true,
+            cmake_dap_configuration = {
+                name = "cpp",
+                type = "codelldb",
+                request = "launch",
+                stopOnEntry = false,
+                runInTerminal = true,
+                console = "integratedTerminal",
+            },
+        },
     },
     {
-        'folke/which-key.nvim',
+        "folke/which-key.nvim",
         opts = {
             spec = {
                 {
-                    '<leader>ck',
-                    group = 'CMake',
-                    icon = { icon = '⚙', color = 'cyan' },
+                    "<leader>ck",
+                    group = "CMake",
+                    icon = { icon = "⚙", color = "cyan" },
                 },
             },
         },


### PR DESCRIPTION
This PR upgrades the `cmake-tools.nvim` integration from a minimal keymap wrapper to a full IDE-grade setup with project auto-detection, lazy-loading optimization, and sensible defaults that feed `clangd` and `nvim-dap` automatically.

### What changed

| Area | Before | After |
|------|--------|-------|
| **Project scope** | Loaded in every directory | `cond = is_cmake_project()` — loads only when `CMakeLists.txt` or `CMakePresets.json` is found upward from cwd/current file |
| **Lazy loading** | `keys` only | `cmd` (all major commands) + `ft = "cmake"` + `keys` — commands exist even before first keypress |
| **Dependencies** | Implicit | Explicit `plenary.nvim` declared |
| **Presets** | Default (`false`) | `cmake_use_preset = true` — matches your heavy-preset workflow |
| **Auto-configure** | Default (`false`) | `cmake_regenerate_on_save = true` — saves in `CMakeLists.txt` trigger re-configure |
| **Compile commands** | Manual symlink | `soft_link` to cwd automatically — `clangd` sees `compile_commands.json` immediately |
| **Target info** | Default (`false`) | `cmake_virtual_text_support = true` — current target shown in virtual text |
| **Debugger** | Not configured | `codelldb` launch preset wired for `:CMakeDebug` |
| **Keymaps** | 15 maps | 17 maps — added `<leader>ckT` (CTest) and `<leader>ckf` (target files) |

### New keymaps

| Key | Command | Purpose |
|-----|---------|---------|
| `<leader>ckg` | `CMakeGenerate` | Configure (preset-aware) |
| `<leader>ckb` | `CMakeBuild` | Build selected target |
| `<leader>ckr` | `CMakeRun` | Run selected launch target |
| `<leader>ckd` | `CMakeDebug` | Debug via codelldb |
| `<leader>ckp` | `CMakeSelectConfigurePreset` | Pick configure preset |
| `<leader>ckP` | `CMakeSelectBuildPreset` | Pick build preset |
| `<leader>ckt` | `CMakeSelectBuildTarget` | Pick build target |
| `<leader>ckl` | `CMakeSelectLaunchTarget` | Pick launch target |
| `<leader>ckT` | `CMakeTest` | Run CTest suite |
| `<leader>ckf` | `CMakeShowTargetFiles` | Show files in current target |
| `<leader>cks` | `CMakeSettings` | Edit project-local settings |

### Why these defaults

- **`cmake_use_preset = true`**: Your workflow is explicitly preset-driven; without this, cmake-tools falls back to kit/variant mode and ignores your `CMakePresets.json`.
- **`soft_link` compile commands**: Removes the manual `ln -s build/compile_commands.json .` step. `clangd` LSP works out of the box after first configure.
- **`codelldb` DAP preset**: Lets `:CMakeDebug` launch the selected target under `nvim-dap` without writing a custom `launch.json`.

### Refs
- https://github.com/Civitasv/cmake-tools.nvim
- https://github.com/Civitasv/cmake-tools.nvim/blob/main/docs/cmake_presets.md
- https://github.com/Civitasv/cmake-tools.nvim/blob/main/docs/howto.md