### PR TITLE
feat(cpp): top-tier IDE plugins and LazyVim extras

### DIFF
--- a/lua/config/lazy.lua
+++ b/lua/config/lazy.lua
@@ -11,9 +11,9 @@ if not (vim.uv or vim.loop).fs_stat(lazypath) then
     })
     if vim.v.shell_error ~= 0 then
         vim.api.nvim_echo({
-            { 'Failed to clone lazy.nvim:\n', 'ErrorMsg' },
+            { 'Failed to clone lazy.nvim:\\n', 'ErrorMsg' },
             { out, 'WarningMsg' },
-            { '\nPress any key to exit...' },
+            { '\\nPress any key to exit...' },
         }, true, {})
         vim.fn.getchar()
         os.exit(1)
@@ -25,26 +25,36 @@ vim.opt.rtp:prepend(lazypath)
 -- loading lazy.nvim so that mappings are correct.
 -- This is also a good place to setup other settings (vim.opt)
 vim.g.mapleader = ' '
-vim.g.maplocalleader = '\\'
+vim.g.maplocalleader = '\\\\'
 
 require('lazy').setup({
     spec = {
         -- add LazyVim and import its plugins
         { 'LazyVim/LazyVim', import = 'lazyvim.plugins' },
+
+        -- C++ / CMake language support (LSP + DAP + build tooling)
         { import = 'lazyvim.plugins.extras.lang.clangd' },
+        { import = 'lazyvim.plugins.extras.lang.cmake' },
         { import = 'lazyvim.plugins.extras.lang.tex' },
+
+        -- DAP / Test / Editor IDE modules
         { import = 'lazyvim.plugins.extras.dap.core' },
+        { import = 'lazyvim.plugins.extras.test.core' },
+        { import = 'lazyvim.plugins.extras.editor.aerial' },
+        { import = 'lazyvim.plugins.extras.editor.inc-rename' },
+        { import = 'lazyvim.plugins.extras.git.diffview' },
+
         -- import/override with your plugins
         { import = 'plugins' },
     },
     defaults = {
         -- By default, only LazyVim plugins will be lazy-loaded. Your custom plugins will load during startup.
-        -- If you know what you're doing, you can set this to `true` to have all your custom plugins lazy-loaded by default.
+        -- If you know what you are doing, you can set this to `true` to have all your custom plugins lazy-loaded by default.
         lazy = false,
         -- It's recommended to leave version=false for now, since a lot the plugin that support versioning,
         -- have outdated releases, which may break your Neovim install.
         version = false, -- always use the latest git commit
-        -- version = "*", -- try installing the latest stable version for plugins that support semver
+        -- version = \"*\", -- try installing the latest stable version for plugins that support semver
     },
     install = {},
     checker = {

--- a/lua/plugins/dap_ui.lua
+++ b/lua/plugins/dap_ui.lua
@@ -1,0 +1,18 @@
+--- IDE-grade debugging UI for C++.
+--- nvim-dap-ui renders scopes, watches, call stack and breakpoints in side panels.
+--- nvim-dap-virtual-text prints variable values inline next to source lines.
+--- Refs:
+---   https://github.com/rcarriga/nvim-dap-ui
+---   https://github.com/theHamsta/nvim-dap-virtual-text
+---   https://github.com/mfussenegger/nvim-dap
+return {
+    {
+        "rcarriga/nvim-dap-ui",
+        dependencies = { "mfussenegger/nvim-dap", "nvim-neotest/nvim-nio" },
+        opts = {},
+    },
+    {
+        "theHamsta/nvim-dap-virtual-text",
+        opts = {},
+    },
+}

--- a/lua/plugins/mason_tools.lua
+++ b/lua/plugins/mason_tools.lua
@@ -1,0 +1,19 @@
+--- Auto-install C++ toolchain binaries via Mason on startup.
+--- Declarative list ensures clangd, codelldb, clang-format and cmake-language-server
+--- are present on fresh machines without manual :MasonInstall steps.
+--- Refs:
+---   https://github.com/WhoIsSethDaniel/mason-tool-installer.nvim
+---   https://github.com/mason-org/mason.nvim
+return {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    dependencies = { "mason-org/mason.nvim" },
+    opts = {
+        ensure_installed = {
+            "clangd",
+            "clang-format",
+            "codelldb",
+            "cmake-language-server",
+        },
+        run_on_start = true,
+    },
+}

--- a/lua/plugins/neogen.lua
+++ b/lua/plugins/neogen.lua
@@ -1,0 +1,13 @@
+--- Generate Doxygen / Javadoc annotations from C++ function signatures.
+--- Place cursor on a method, trigger mapping, and param/return blocks are auto-written.
+--- Refs:
+---   https://github.com/danymat/neogen
+---   https://github.com/nvim-treesitter/nvim-treesitter
+return {
+    "danymat/neogen",
+    keys = {
+        { "<leader>cn", function() require("neogen").generate() end, desc = "Generate doc comment" },
+    },
+    dependencies = "nvim-treesitter/nvim-treesitter",
+    opts = { snippet_engine = "luasnip" },
+}

--- a/lua/plugins/neotest.lua
+++ b/lua/plugins/neotest.lua
@@ -1,0 +1,15 @@
+--- Google Test adapter for Neotest.
+--- Auto-discovers gtest executables and runs individual TEST_F cases inside Neovim.
+--- Refs:
+---   https://github.com/alfaix/neotest-gtest
+---   https://github.com/nvim-neotest/neotest
+return {
+    {
+        "nvim-neotest/neotest",
+        dependencies = { "alfaix/neotest-gtest" },
+        opts = function(_, opts)
+            opts.adapters = opts.adapters or {}
+            table.insert(opts.adapters, require("neotest-gtest"))
+        end,
+    },
+}

--- a/lua/plugins/overseer.lua
+++ b/lua/plugins/overseer.lua
@@ -1,0 +1,8 @@
+--- Task runner for CMake presets, build targets and ctest jobs.
+--- Replaces manual terminal invocations with a unified task panel.
+--- Ref:
+---   https://github.com/stevearc/overseer.nvim
+return {
+    "stevearc/overseer.nvim",
+    opts = {},
+}

--- a/lua/plugins/treesj.lua
+++ b/lua/plugins/treesj.lua
@@ -1,0 +1,13 @@
+--- Toggle single-line / multi-line C++ syntax blocks.
+--- Useful for function arguments, initializer lists, if/else braces.
+--- Refs:
+---   https://github.com/Wansmer/treesj
+---   https://github.com/nvim-treesitter/nvim-treesitter
+return {
+    "Wansmer/treesj",
+    keys = {
+        { "<leader>cm", function() require("treesj").toggle() end, desc = "Toggle syntax block" },
+    },
+    dependencies = { "nvim-treesitter/nvim-treesitter" },
+    opts = { use_default_keymaps = false },
+}


### PR DESCRIPTION
This PR closes #2 by adding the essential missing pieces for a top-tier C++ IDE inside Neovim.

### LazyVim extras enabled (zero custom code)

| Extra | What it gives you | Why for C++ |
|-------|-------------------|-------------|
| `lazyvim.plugins.extras.lang.cmake` | `cmake-language-server` LSP + `cmakelint` | CMakeLists.txt IntelliSense |
| `lazyvim.plugins.extras.test.core` | `neotest` framework + summary panel | Unified test runner |
| `lazyvim.plugins.extras.editor.aerial` | `aerial.nvim` symbol outline | Navigate class hierarchy |
| `lazyvim.plugins.extras.editor.inc-rename` | `inc-rename.nvim` | Live rename preview |
| `lazyvim.plugins.extras.git.diffview` | `diffview.nvim` | Side-by-side git history / PR review |

### New custom plugins (minimal config, upstream defaults)

| Plugin | File | Purpose | Ref |
|--------|------|---------|-----|
| `rcarriga/nvim-dap-ui` | `lua/plugins/dap_ui.lua` | Scopes, watches, call stack, breakpoints panel | [repo](https://github.com/rcarriga/nvim-dap-ui) |
| `theHamsta/nvim-dap-virtual-text` | `lua/plugins/dap_ui.lua` | Variable values inline while stepping | [repo](https://github.com/theHamsta/nvim-dap-virtual-text) |
| `alfaix/neotest-gtest` | `lua/plugins/neotest.lua` | Google Test adapter for `neotest` | [repo](https://github.com/alfaix/neotest-gtest) |
| `stevearc/overseer.nvim` | `lua/plugins/overseer.lua` | CMake preset / build task runner | [repo](https://github.com/stevearc/overseer.nvim) |
| `danymat/neogen` | `lua/plugins/neogen.lua` | Doxygen comment generation from signatures | [repo](https://github.com/danymat/neogen) |
| `Wansmer/treesj` | `lua/plugins/treesj.lua` | Toggle single/multi-line C++ blocks | [repo](https://github.com/Wansmer/treesj) |
| `WhoIsSethDaniel/mason-tool-installer.nvim` | `lua/plugins/mason_tools.lua` | Auto-install `clangd`, `codelldb`, `clang-format`, `cmake-language-server` on fresh machines | [repo](https://github.com/WhoIsSethDaniel/mason-tool-installer.nvim) |

### Design decisions

- Every new plugin uses `opts = {}` or explicit upstream defaults unless a keymap is essential (neogen, treesj).
- `mason-tool-installer` runs on startup so a fresh clone on a new workstation immediately provisions the C++ toolchain.
- `neotest-gtest` extends LazyVim's `test.core` extra via the standard Lazy.nvim `opts` merge pattern.
- No bloat: `aerial`, `inc-rename`, `diffview` are pure LazyVim extras — no custom code to maintain.