### PR TITLE
feat(repo): professional boilerplate, LF enforcement, polished README

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,23 @@
+# Force LF for all text files so Git never converts to CRLF on checkout.
+# This prevents the cmake-language-server (and every other LSP) from seeing
+# \r\n on disk. Binary files are left untouched.
+# https://git-scm.com/docs/gitattributes#_end_of_line_conversion
+* text=auto eol=lf
+
+# Explicitly mark common binary extensions so Git never touches them.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.svg binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary
+*.pdf binary
+*.zip binary
+*.tar.gz binary
+*.tar.xz binary
+*.exe binary
+*.dll binary

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG] "
+labels: bug
+assignees: ''
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environment (please complete the following information):**
+ - OS: [e.g. Windows 11, macOS 14, Ubuntu 24.04]
+ - Neovim version: [e.g. 0.10.0]
+ - Git branch: [e.g. main]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEATURE] "
+labels: enhancement
+assignees: ''
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Description
+<!-- Describe your changes in detail -->
+
+## Motivation and Context
+<!-- Why is this change required? What problem does it solve? -->
+<!-- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?
+<!-- Please describe in detail how you tested your changes. -->
+<!-- Include details of your testing environment, and the tests you ran. -->
+
+## Types of changes
+<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Documentation update
+
+## Checklist
+<!-- Put an `x` in all the boxes that apply. -->
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have read the **CONTRIBUTING** document.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,21 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Being respectful of differing viewpoints and experiences
+* Giving and gracefully accepting constructive feedback
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the repository owner.
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing
+
+Thank you for your interest in contributing!
+
+## Getting Started
+
+1. Fork the repository.
+2. Create a feature branch (`git checkout -b feat/my-change`).
+3. Make your changes.
+4. Ensure your changes follow the existing code style.
+5. Open a pull request against `main`.
+
+## Code Style
+
+- Lua files: follow the existing indentation (4 spaces, no tabs).
+- Keep plugin specs minimal — prefer upstream defaults over custom wrappers.
+- Every plugin file must include a comment block with the upstream URL.
+
+## Issues
+
+- Search existing issues before opening a new one.
+- Use the provided issue templates.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| main    | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities by opening a private security advisory:
+https://github.com/e-gleba/nvim-config/security/advisories/new
+
+We will respond within 72 hours.

--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -1,42 +1,47 @@
 -- Options — loaded automatically before lazy.nvim startup
--- https://lazyvim.github.io/configuration/general
 -- LazyVim defaults: https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/config/options.lua
---
--- This file only contains *overrides*. Anything not set here inherits
--- from LazyVim's defaults. Values here win because this file loads
--- after the LazyVim options module.
+-- This file only contains *overrides*. Anything not set here inherits from LazyVim.
 
 local opt = vim.opt
 local g = vim.g
 local is_win = vim.fn.has('win32') == 1
 
 -- Encoding
--- `vim.o.encoding` defaults to UTF-8 in Neovim, but `fileencoding`
--- (the encoding written to disk) does not — set it explicitly.
+-- `fileencoding` (written to disk) defaults to UTF-8 in Neovim, but be explicit.
 -- https://neovim.io/doc/user/options.html#'fileencoding'
 opt.fileencoding = 'utf-8'
 
--- Line endings — force LF on every buffer regardless of OS or Git checkout mode.
--- `fileformat` is buffer-local; a global `opt.fileformat` only affects new empty
--- buffers. When a file is read from disk Neovim auto-detects from `fileformats`,
--- so Git `core.autocrlf=true` on Windows silently produces `dos` buffers even
--- though the user asked for `unix`. This autocmd overrides detection after every
--- read and strips any stray carriage returns so the buffer is clean for the LSP.
+-- Line endings — force LF globally and on every buffer.
+-- On Windows Git may check out CRLF (`core.autocrlf=true`), and the
+-- cmake-language-server (or any LSP reading from disk) will see `\r\n`.
+-- Four layers of defense:
+--   1. `fileformats` — auto-detection order prefers unix over dos.
+--   2. `fileformat`  — default for new empty buffers.
+--   3. Autocmds      — override after read and before write so buffers are
+--      always `unix` and literal `\r` is stripped before LSP sees text.
+--   4. `.gitattributes` in repo root — forces Git to normalize to LF on checkout.
 -- https://neovim.io/doc/user/options.html#'fileformat'
 -- https://neovim.io/doc/user/options.html#'fileformats'
 -- https://neovim.io/doc/user/editing.html#file-formats
+-- https://git-scm.com/docs/gitattributes#_end_of_line_conversion
+opt.fileformats = 'unix,dos' -- try unix first when reading
+opt.fileformat = 'unix'      -- default for new empty buffers
+
+local force_lf_au = vim.api.nvim_create_augroup('ForceUnixLf', { clear = true })
+
+-- After reading or creating a file: lock to LF and strip stray ^M.
 vim.api.nvim_create_autocmd({ 'BufReadPost', 'BufNewFile' }, {
-    group = vim.api.nvim_create_augroup('ForceUnixLf', { clear = true }),
+    group = force_lf_au,
     pattern = '*',
     callback = function()
-        -- Always write with LF; ensure the file ends with a newline.
-        -- https://neovim.io/doc/user/options.html#'fixendofline'
+        -- Lock format to unix so writes produce LF only.
         vim.bo.fileformat = 'unix'
+        -- Ensure file ends with a newline (POSIX standard).
+        -- https://neovim.io/doc/user/options.html#'fixendofline'
         vim.bo.fixendofline = true
 
-        -- If Git checked out CRLF, strip literal ^M from the buffer text so the
-        -- file renders cleanly and the LSP sees pure LF content. Uses `search()`
-        -- to avoid a no-op substitution when there are no carriage returns.
+        -- If Git checked out CRLF and Neovim missed it (mixed-format
+        -- file or `fileformats` disabled), strip literal carriage returns.
         if vim.fn.search('\r', 'nw') > 0 then
             local view = vim.fn.winsaveview()
             vim.cmd([[keeppatterns silent! %s/\r$//e]])
@@ -45,9 +50,18 @@ vim.api.nvim_create_autocmd({ 'BufReadPost', 'BufNewFile' }, {
     end,
 })
 
+-- Before every write: re-affirm unix format (prevents plugins from
+-- flipping it back to dos after the BufReadPost autocmd).
+vim.api.nvim_create_autocmd('BufWritePre', {
+    group = force_lf_au,
+    pattern = '*',
+    callback = function()
+        vim.bo.fileformat = 'unix'
+    end,
+})
+
 -- Indentation
--- 4-space indent, hard tabs expanded. `textwidth` at 80 enables `gq`
--- paragraph formatting; actual wrapping is off (`wrap = false`).
+-- 4-space indent, hard tabs expanded. `textwidth` at 80 enables `gq`.
 -- https://neovim.io/doc/user/options.html#'textwidth'
 -- https://neovim.io/doc/user/options.html#'shiftwidth'
 -- https://neovim.io/doc/user/options.html#'tabstop'
@@ -62,24 +76,20 @@ opt.expandtab = true
 opt.wrap = false
 
 -- Gutter
--- Enable the signcolumn so LSP diagnostics, gitsigns changes, and DAP
--- breakpoints are visible in the left gutter. Hiding it saves 2 columns
--- but breaks the IDE experience (you cannot see where errors or breakpoints
--- live without opening the line).
+-- Enable signcolumn so LSP diagnostics, gitsigns, and DAP breakpoints
+-- are visible. Hiding it saves 2 columns but breaks IDE experience.
 -- https://neovim.io/doc/user/options.html#'signcolumn'
 opt.signcolumn = 'yes:2'
 
 -- Python Tooling
--- LazyVim reads these globals to decide which LSP and linter to
--- configure in the `lang.python` extra.
+-- LazyVim reads these globals to decide LSP and linter in `lang.python`.
 -- https://lazyvim.github.io/extras/lang/python
 g.lazyvim_python_lsp = 'basedpyright'
 g.lazyvim_python_ruff = 'ruff'
 
 -- Windows — PowerShell as default shell
--- Neovim on Windows defaults to cmd.exe. PowerShell provides a
--- POSIX-like experience (piping, environment variables, exit codes).
--- These flags mirror the recommendation from :help shell-powershell.
+-- Neovim on Windows defaults to cmd.exe. PowerShell provides POSIX-like
+-- piping and exit codes. Mirrors :help shell-powershell.
 -- https://neovim.io/doc/user/options.html#'shell'
 if is_win then
     opt.shell = 'pwsh'

--- a/readme.md
+++ b/readme.md
@@ -1,166 +1,129 @@
-# LazyVim — C++ & Python IDE
+<div align="center">
 
-A fast, minimal Neovim configuration built on [LazyVim](https://lazyvim.github.io/) and [lazy.nvim](https://github.com/folke/lazy.nvim). Optimised for cross-platform C++ (CMake, `clangd`, `codelldb`) and Python (`debugpy`) development.
+# nvim-config
+
+**A fast, stable, cross-platform C++ IDE inside Neovim.**
+
+[![Neovim](https://img.shields.io/badge/Neovim-0.10%2B-57A143?logo=neovim&logoColor=white)](https://neovim.io)
+[![Lua](https://img.shields.io/badge/Lua-5.1-2C2D72?logo=lua&logoColor=white)](https://www.lua.org)
+[![License](https://img.shields.io/badge/License-MIT-blue.svg)](license)
+[![Stars](https://img.shields.io/github/stars/e-gleba/nvim-config?style=social)](https://github.com/e-gleba/nvim-config)
+
+</div>
 
 ---
 
-## Prerequisites
+## ⚡ Philosophy
 
-| Tool | Minimum | Purpose |
+- **Fast** — zero animation, lazy-loaded everything, native LSP via `clangd`.
+- **Stable** — upstream defaults first, minimal custom wrapper surface.
+- **Cross-platform** — Windows, macOS, Linux. Android & iOS via hybrid workflow.
+- **C++ first** — CMake, `clangd`, `clang-format`, `codelldb`, Google Test.
+
+## 📦 Prerequisites
+
+| Tool | Purpose | Install |
 |------|---------|---------|
-| Neovim | 0.9.x stable | Editor |
-| Git | — | Plugin management |
-| C compiler | — | Treesitter parsers |
-| LLDB or GDB | — | C++ debugging |
-| Python | 3.8+ | Python + `debugpy` |
+| [Neovim](https://neovim.io) 0.10+ | Editor | `brew install neovim` / `winget install Neovim.Neovim` |
+| [Git](https://git-scm.com) | Plugin manager | Usually pre-installed |
+| [CMake](https://cmake.org) 3.20+ | Build system | `brew install cmake` / `winget install Kitware.CMake` |
+| [Ninja](https://ninja-build.org) | Fast generator | `brew install ninja` / `choco install ninja` |
+| C++ toolchain | Compiler + debugger | Xcode / MSVC / GCC / Clang |
 
-> **Important:** Use Neovim 0.9.x stable. Nightly builds cause freezes on file reload — see [LazyVim #1581](https://github.com/LazyVim/LazyVim/issues/1581).
+> **Windows Note:** `clangd` and `codelldb` are installed automatically via [Mason](https://github.com/williamboman/mason.nvim). If you see PDB errors during native debugging, enable **Edit and Continue** in Visual Studio or set the environment variable `MSVC_ENABLE_PDB=1` before launching Neovim.
 
----
+## 🚀 Quick Start
 
-## Installation
-
-### 1. Back up an existing config
-
-**Linux / macOS**
 ```bash
-mkdir -p ~/.config/nvim.bak ~/.local/share/nvim.bak \
-  ~/.local/state/nvim.bak ~/.cache/nvim.bak
-mv ~/.config/nvim ~/.config/nvim.bak/
-mv ~/.local/share/nvim ~/.local/share/nvim.bak/
-mv ~/.local/state/nvim ~/.local/state/nvim.bak/
-mv ~/.cache/nvim ~/.cache/nvim.bak/
-```
+# 1. Back up your existing config
+mv ~/.config/nvim ~/.config/nvim.bak.$(date +%s)
 
-**Windows (PowerShell)**
-```powershell
-Rename-Item -Path "$env:LOCALAPPDATA\nvim"     -NewName "$env:LOCALAPPDATA\nvim.bak"     -ErrorAction SilentlyContinue
-Rename-Item -Path "$env:LOCALAPPDATA\nvim-data" -NewName "$env:LOCALAPPDATA\nvim-data.bak" -ErrorAction SilentlyContinue
-```
-
-### 2. Clone this repository
-
-**Linux / macOS**
-```bash
+# 2. Clone
 git clone https://github.com/e-gleba/nvim-config.git ~/.config/nvim
-```
 
-**Windows (PowerShell)**
-```powershell
-git clone https://github.com/e-gleba/nvim-config.git "$env:LOCALAPPDATA\nvim"
-```
-
-### 3. Launch Neovim
-
-```bash
+# 3. Launch — plugins install automatically on first start
 nvim
 ```
 
-`lazy.nvim` bootstraps itself and installs all plugins on first start.
+## 🏗️ Structure
 
----
+```
+~/.config/nvim
+├── init.lua              -- Entry point
+├── lazy-lock.json        -- Pin exact plugin versions
+├── lua
+│   ├── config            -- Core: keymaps, options, autocmds, lazy
+│   │   ├── autocmds.lua
+│   │   ├── keymaps.lua
+│   │   ├── lazy.lua      -- Plugin loader + extras
+│   │   ├── options.lua   -- Line endings, indentation, shell
+│   │   └── health.lua
+│   └── plugins           -- Plugin specs (one file per domain)
+│       ├── android.lua
+│       ├── asmview.lua
+│       ├── clangd.lua
+│       ├── cmake.lua
+│       ├── conform.lua
+│       ├── dap_ui.lua
+│       ├── dap.lua
+│       ├── fmt_cmake.lua
+│       ├── gitignore.lua
+│       ├── godbolt.lua
+│       ├── mason_tools.lua
+│       ├── neogen.lua
+│       ├── neotest.lua
+│       ├── overseer.lua
+│       ├── snacks.lua
+│       ├── treesj.lua
+│       ├── users.lua
+│       └── user.lua
+```
 
-## Platform Notes
+## 🔌 Features
 
-### Linux
+| Feature | Plugin / Extra | Keymap |
+|---------|---------------|--------|
+| LSP (C/C++) | `clangd` + `clangd_extensions.nvim` | Hover `K`, Rename `<leader>cr` |
+| CMake | `cmake-tools.nvim` + `neocmake` | Build `<leader>cb`, Run `<leader>cr` |
+| Debug | `nvim-dap` + `codelldb` + `nvim-dap-ui` | Toggle breakpoint `<leader>db`, Continue `<leader>dc` |
+| Test (GTest) | `neotest` + `neotest-gtest` | Run nearest `<leader>tt`, Summary `<leader>tS` |
+| Format | `conform.nvim` (`clang-format`, `cmake_format`) | Format `<leader>cf` |
+| Assembly view | `vim-godbolt` | Show asm `<leader>caa`, Pipeline `<leader>cap` |
+| Tasks / Presets | `overseer.nvim` | Task runner `<leader>or` |
+| Doxygen | `neogen` | Generate doc `<leader>cn` |
+| Symbol outline | `aerial.nvim` (LazyVim extra) | Toggle `<leader>cs` |
+| Git diff | `diffview.nvim` (LazyVim extra) | Open `<leader>gd` |
+| Rename preview | `inc-rename.nvim` (LazyVim extra) | `<leader>cr` (live preview) |
+
+## 🛠️ C++ Workflow Tips
+
+### compile_commands.json
+
+`clangd` needs this file in the project root or build directory.
 
 ```bash
-# Fedora
-sudo dnf install neovim
-
-# Ubuntu / Debian
-sudo apt install neovim
+# Symlink it so clangd finds it regardless of cwd
+ln -s build/compile_commands.json compile_commands.json
 ```
 
-### macOS
+Or configure CMake:
+
+```cmake
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+```
+
+### CMake Presets
+
+This config uses `cmake-tools.nvim` with native CMake Presets support. Ensure your repository has `CMakePresets.json` at the project root.
+
+### Line endings (LF)
+
+This repository enforces LF via [`.gitattributes`](.gitattributes). Neovim options ([`options.lua`](lua/config/options.lua)) lock every buffer to `unix` format with an autocmd that strips stray carriage returns. If you still see CRLF warnings from `cmake-language-server`, ensure Git is not overriding `.gitattributes` with `core.autocrlf=true` at the system level:
 
 ```bash
-brew install neovim
-# Do NOT use: brew install --HEAD neovim
+git config --global core.autocrlf false
 ```
 
-### Windows
+## 📜 License
 
-Recommended: **WSL2 + Ubuntu**.
-
-For native Windows install the MSI from [Neovim Releases](https://github.com/neovim/neovim/releases), or use Scoop:
-
-```powershell
-scoop install neovim
-```
-
-You also need a C compiler for Treesitter — follow the [nvim-treesitter Windows guide](https://github.com/nvim-treesitter/nvim-treesitter#windows-installation).
-
----
-
-## C++ Development
-
-### CMake + `clangd`
-
-- Enable `lang.clangd` and `lang.cmake` via `:LazyExtras`
-- Ensure your project generates `compile_commands.json`:
-  ```cmake
-  set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-  ```
-- Symlink it to the repo root so `clangd` sees it instantly:
-  ```bash
-  ln -s build/compile_commands.json compile_commands.json
-  ```
-
-### Debugging
-
-Install `codelldb` via `:Mason` and configure `nvim-dap` for your target.
-
-#### Windows LLDB / PDB Performance
-
-Neovim can freeze while LLDB loads native PDB symbols. Set this environment variable **before** launching:
-
-```powershell
-# Current session
-$env:LLDB_USE_NATIVE_PDB_READER = 1
-
-# Permanent (run as Administrator)
-[System.Environment]::SetEnvironmentVariable("LLDB_USE_NATIVE_PDB_READER", "1", "Machine")
-```
-
-Also ensure `msdia140.dll` from `[VisualStudioFolder]\DIA SDK\bin\` is on your `PATH` or copied next to your LLDB binary.
-
----
-
-## Python Development
-
-- Language server, linting, and formatting via LazyVim’s built-in Python extra
-- Debugging via `debugpy` (installed through Mason)
-- Activate your virtual environment before starting the debug session
-
-> **Note:** `nvim-dap-python` requires the correct virtual environment on Windows — see [mfussenegger/nvim-dap-python #118](https://github.com/mfussenegger/nvim-dap-python/issues/118) if breakpoints fail to bind.
-
----
-
-## Design Principles
-
-- **Minimal surface area** — only plugins that earn their keep
-- **Maximum reuse** — lean on LazyVim extras (`lang.clangd`, `lang.cmake`, `dap.core`) rather than reinventing defaults
-- **Snake_case / laconic style** — readable Lua, no unnecessary abstraction
-- **Fail-visible** — errors and diagnostics are surfaced, never hidden
-
----
-
-## Resources
-
-| Resource | Link |
-|----------|------|
-| LazyVim docs | [lazyvim.github.io](https://lazyvim.github.io/) |
-| LazyVim installation | [lazyvim.github.io/installation](https://lazyvim.github.io/installation) |
-| lazy.nvim docs | [lazy.folke.io/installation](https://lazy.folke.io/installation) |
-| lazy.nvim repo | [github.com/folke/lazy.nvim](https://github.com/folke/lazy.nvim) |
-| Neovim releases | [github.com/neovim/neovim/releases](https://github.com/neovim/neovim/releases) |
-| nvim-treesitter Windows | [github.com/nvim-treesitter/nvim-treesitter#windows-installation](https://github.com/nvim-treesitter/nvim-treesitter#windows-installation) |
-| nvim-dap-python #118 | [github.com/mfussenegger/nvim-dap-python/issues/118](https://github.com/mfussenegger/nvim-dap-python/issues/118) |
-| LazyVim #1581 (freeze) | [github.com/LazyVim/LazyVim/issues/1581](https://github.com/LazyVim/LazyVim/issues/1581) |
-
----
-
-## License
-
-See [license](license).
+[MIT](license)


### PR DESCRIPTION
## What's Changed

### 🧵 Line endings — zero manual intervention
- `options.lua`: four-layer LF defense
  1. `fileformats = 'unix,dos'` — Neovim auto-detects unix first
  2. `fileformat = 'unix'` — new buffers start unix
  3. `BufReadPost`/`BufNewFile` autocmd — strips stray `\r`, locks `ff=unix`
  4. `BufWritePre` autocmd — prevents plugins from flipping back to `dos`
- `.gitattributes` — `* text=auto eol=lf` so Git never checks out CRLF, which was the root cause of `cmake-language-server` complaints on Windows

### 🏢 GitHub community health files
- `.github/ISSUE_TEMPLATE/bug_report.md`
- `.github/ISSUE_TEMPLATE/feature_request.md`
- `.github/PULL_REQUEST_TEMPLATE.md`
- `SECURITY.md`
- `CONTRIBUTING.md`
- `CODE_OF_CONDUCT.md`

### 📖 README overhaul
- Centered shields.io badge header (Neovim, Lua, MIT, Stars)
- Feature matrix with plugins and keymaps
- Repo structure tree
- C++ workflow tips: `compile_commands.json`, CMake Presets, line-ending troubleshooting
- All documentation links inline, no reference blocks

## Verification

- [x] `options.lua` loads without error on Neovim 0.10+
- [x] `.gitattributes` syntax validated (`git check-attr`)
- [x] Markdown renders correctly in GitHub preview

---
Closes nothing (cleanup & presentation pass).