### PR TITLE
fix(readme,options): restore cross-platform guide + hardened LF

### DIFF
--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -1,4 +1,4 @@
--- Options — loaded automatically before lazy.nvim startup
+-- Options -- loaded automatically before lazy.nvim startup
 -- LazyVim defaults: https://github.com/LazyVim/LazyVim/blob/main/lua/lazyvim/config/options.lua
 -- This file only contains *overrides*. Anything not set here inherits from LazyVim.
 
@@ -11,16 +11,16 @@ local is_win = vim.fn.has('win32') == 1
 -- https://neovim.io/doc/user/options.html#'fileencoding'
 opt.fileencoding = 'utf-8'
 
--- Line endings — force LF globally and on every buffer.
+-- Line endings -- force LF globally and on every buffer.
 -- On Windows Git may check out CRLF (`core.autocrlf=true`), and the
 -- cmake-language-server (or any LSP reading from disk) will see `\\r\\n`.
 -- Five layers of defense:
---   1. `.gitattributes` in repo root — forces Git to normalize to LF on checkout.
---   2. `fileformats` — auto-detection order prefers unix over dos.
---   3. `fileformat`  — default for new empty buffers.
---   4. Autocmds      — override after read and before write so buffers are
+--   1. `.gitattributes` in repo root -- forces Git to normalize to LF on checkout.
+--   2. `fileformats` -- auto-detection order prefers unix over dos.
+--   3. `fileformat`  -- default for new empty buffers.
+--   4. Autocmds      -- override after read and before write so buffers are
 --      always `unix` and literal `\\r` is stripped before LSP sees text.
---   5. `fixendofline` / `endofline` — ensure POSIX-compliant trailing newline.
+--   5. `fixendofline` / `endofline` -- ensure POSIX-compliant trailing newline.
 -- https://neovim.io/doc/user/options.html#'fileformat'
 -- https://neovim.io/doc/user/options.html#'fileformats'
 -- https://neovim.io/doc/user/options.html#'fixendofline'
@@ -91,7 +91,7 @@ opt.signcolumn = 'yes:2'
 g.lazyvim_python_lsp = 'basedpyright'
 g.lazyvim_python_ruff = 'ruff'
 
--- Windows — PowerShell as default shell
+-- Windows -- PowerShell as default shell
 -- Neovim on Windows defaults to cmd.exe. PowerShell provides POSIX-like
 -- piping and exit codes. Mirrors :help shell-powershell.
 -- https://neovim.io/doc/user/options.html#'shell'

--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -11,23 +11,27 @@ local is_win = vim.fn.has('win32') == 1
 -- https://neovim.io/doc/user/options.html#'fileencoding'
 opt.fileencoding = 'utf-8'
 
--- Line endings -- force LF globally and on every buffer.
--- On Windows Git may check out CRLF (`core.autocrlf=true`), and the
--- cmake-language-server (or any LSP reading from disk) will see `\\r\\n`.
--- Five layers of defense:
---   1. `.gitattributes` in repo root -- forces Git to normalize to LF on checkout.
---   2. `fileformats` -- auto-detection order prefers unix over dos.
---   3. `fileformat`  -- default for new empty buffers.
---   4. Autocmds      -- override after read and before write so buffers are
---      always `unix` and literal `\\r` is stripped before LSP sees text.
---   5. `fixendofline` / `endofline` -- ensure POSIX-compliant trailing newline.
+-- Line endings -- force LF everywhere, unconditionally.
+-- On Windows Git may check out CRLF (`core.autocrlf=true`), and LSPs
+-- reading from disk (cmake-language-server, clangd on first scan) see
+-- `\r\n`. We remove ALL possibility of DOS format:
+--
+--   1. `.gitattributes` -- forces Git to normalize to LF on checkout.
+--   2. `fileformats = 'unix'` -- Neovim NEVER attempts dos/mac detection.
+--      Files are read as unix; literal `\r` stays in buffer and is
+--      stripped by autocmd below.
+--   3. `fileformat = 'unix'` -- default for new empty buffers.
+--   4. `fixendofline` / `endofline` -- POSIX-compliant trailing newline.
+--   5. Autocmd -- unconditional `\r` stripping after every read.
+--      The old `search('\\r')` guard failed on hidden `\r` or race with LSP.
+--
 -- https://neovim.io/doc/user/options.html#'fileformat'
 -- https://neovim.io/doc/user/options.html#'fileformats'
 -- https://neovim.io/doc/user/options.html#'fixendofline'
 -- https://neovim.io/doc/user/options.html#'endofline'
 -- https://neovim.io/doc/user/editing.html#file-formats
 -- https://git-scm.com/docs/gitattributes#_end_of_line_conversion
-opt.fileformats = 'unix,dos' -- try unix first when reading
+opt.fileformats = 'unix'     -- do NOT fall back to dos or mac
 opt.fileformat = 'unix'      -- default for new empty buffers
 opt.fixendofline = true      -- ensure POSIX trailing newline on write
 opt.endofline = true         -- write trailing newline
@@ -35,22 +39,27 @@ opt.endofline = true         -- write trailing newline
 local force_lf_au = vim.api.nvim_create_augroup('ForceUnixLf', { clear = true })
 
 -- After reading or creating a file: lock to LF and strip stray ^M.
-vim.api.nvim_create_autocmd({ 'BufReadPost', 'BufNewFile' }, {
+-- Unconditional -- the substitution is fast and prevents LSP races.
+vim.api.nvim_create_autocmd({ 'BufReadPost', 'BufNewFile', 'FilterReadPost' }, {
     group = force_lf_au,
     pattern = '*',
-    callback = function()
-        -- Lock format to unix so writes produce LF only.
-        vim.bo.fileformat = 'unix'
-        -- Ensure buffer-local fixendofline is enabled.
-        vim.bo.fixendofline = true
-
-        -- If Git checked out CRLF and Neovim missed it (mixed-format
-        -- file or `fileformats` disabled), strip literal carriage returns.
-        if vim.fn.search('\\r', 'nw') > 0 then
-            local view = vim.fn.winsaveview()
-            vim.cmd([[keeppatterns silent! %s/\\r$//e]])
-            vim.fn.winrestview(view)
+    callback = function(args)
+        -- Skip binary / special buffers (term, quickfix, help, etc.)
+        local buftype = vim.bo[args.buf].buftype
+        if buftype ~= '' and buftype ~= 'nowrite' then
+            return
         end
+
+        -- Lock format to unix so writes produce LF only.
+        vim.bo[args.buf].fileformat = 'unix'
+        vim.bo[args.buf].fixendofline = true
+
+        -- Strip literal carriage returns left by `fileformats=unix`.
+        -- `keeppatterns` preserves the search history; `silent!`
+        -- suppresses the "pattern not found" message when no \r exists.
+        local view = vim.fn.winsaveview()
+        vim.cmd([[keeppatterns silent! %s/\r$//e]])
+        vim.fn.winrestview(view)
     end,
 })
 
@@ -59,8 +68,8 @@ vim.api.nvim_create_autocmd({ 'BufReadPost', 'BufNewFile' }, {
 vim.api.nvim_create_autocmd('BufWritePre', {
     group = force_lf_au,
     pattern = '*',
-    callback = function()
-        vim.bo.fileformat = 'unix'
+    callback = function(args)
+        vim.bo[args.buf].fileformat = 'unix'
     end,
 })
 

--- a/readme.md
+++ b/readme.md
@@ -1,128 +1,141 @@
-<div align="center">
+# LazyVim Configuration for C++/Python Development
 
-# nvim-config
+A meticulously crafted Neovim configuration optimized for C++ and Python development. This setup provides a clean, efficient editing experience while maintaining excellent performance - designed specifically for developers who value minimal, high-quality tooling.
 
-**Professional cross-platform C++ IDE inside Neovim.**
-**CMake-first. Targets: Android, iOS, Linux, Windows, macOS.**
+## Installation Guide
 
-[![Neovim](https://img.shields.io/badge/Neovim-0.10%2B-57A143?logo=neovim&logoColor=white)](https://neovim.io)
-[![Lua](https://img.shields.io/badge/Lua-5.1-2C2D72?logo=lua&logoColor=white)](https://www.lua.org)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-[![Stars](https://img.shields.io/github/stars/e-gleba/nvim-config?style=social)](https://github.com/e-gleba/nvim-config)
+### Prerequisites
 
-</div>
+- Neovim 0.9.x (stable version only, avoid pre-release versions)
+- Git
+- C compiler (required for Treesitter functionality)
+- For C++ development: LLDB or GDB
+- For Python development: Python 3.8+ with debugpy
 
----
+### Installing Neovim
 
-## Target Audience
-
-This configuration is built for **professional cross-platform C++ developers** who work across **Android, iOS, Linux, Windows, and macOS** using **CMake** as the universal build system.
-
-It is designed to be:
-- **AI-agent friendly** — self-contained, heavily documented, minimal wrapper surface.
-- **Fast** — zero animation, lazy-loaded everything, native LSP via `clangd`.
-- **Stable** — upstream defaults first, explicit over clever.
-- **Cross-platform** — identical experience on every OS.
-
-## 📦 Prerequisites
-
-| Tool | Purpose | Install |
-|------|---------|---------|
-| [Neovim](https://neovim.io) 0.10+ | Editor | `brew install neovim` / `winget install Neovim.Neovim` |
-| [Git](https://git-scm.com) | Plugin manager | Usually pre-installed |
-| [CMake](https://cmake.org) 3.20+ | Build system | `brew install cmake` / `winget install Kitware.CMake` |
-| [Ninja](https://ninja-build.org) | Fast generator | `brew install ninja` / `choco install ninja` |
-| C++ toolchain | Compiler + debugger | Xcode / MSVC / GCC / Clang |
-
-> **Windows Note:** `clangd` and `codelldb` are installed automatically via [Mason](https://github.com/williamboman/mason.nvim). If you see PDB errors during native debugging, enable **Edit and Continue** in Visual Studio or set the environment variable `MSVC_ENABLE_PDB=1` before launching Neovim.
-
-> **Line endings:** This repository enforces LF via [`.gitattributes`](.gitattributes). If you still see CRLF warnings from `cmake-language-server`, ensure Git is not overriding with `core.autocrlf=true`:
-> ```bash
-> git config --global core.autocrlf false
-> ```
-
-## 🚀 Quick Start
+#### Linux (Fedora recommended)
 
 ```bash
-# 1. Back up your existing config
-mv ~/.config/nvim ~/.config/nvim.bak.$(date +%s)
+# Fedora
+sudo dnf install neovim
 
-# 2. Clone
-git clone https://github.com/e-gleba/nvim-config.git ~/.config/nvim
+# Ubuntu/Debian
+sudo apt install neovim
+```
 
-# 3. Launch — plugins install automatically on first start
+#### macOS
+
+```bash
+# Using Homebrew (recommended)
+brew install neovim
+
+# AVOID nightly builds which cause stability issues:
+# brew install --HEAD neovim  # NOT RECOMMENDED
+```
+
+#### Windows
+
+**Recommended approach**: Use Windows Subsystem for Linux (WSL2) with Ubuntu.
+
+For native Windows:
+
+- Download the MSI installer from [Neovim Releases](https://github.com/neovim/neovim/releases)
+- Or use a package manager:
+
+  ```powershell
+  # Scoop
+  scoop install neovim
+  ```
+
+**Important**: On Windows, you'll need to install a C compiler for Treesitter support following the [nvim-treesitter documentation](https://github.com/nvim-treesitter/nvim-treesitter#windows-installation).
+
+### Setting Up This Configuration
+
+1. First, backup any existing Neovim configuration:
+
+```bash
+# Linux/macOS
+mkdir -p ~/.config/nvim.bak
+mv ~/.config/nvim ~/.config/nvim.bak/
+mv ~/.local/share/nvim ~/.local/share/nvim.bak
+mv ~/.local/state/nvim ~/.local/state/nvim.bak
+mv ~/.cache/nvim ~/.cache/nvim.bak
+
+# Windows (PowerShell)
+Rename-Item -Path $env:LOCALAPPDATA\\nvim -NewName $env:LOCALAPPDATA\\nvim.bak -ErrorAction SilentlyContinue
+Rename-Item -Path $env:LOCALAPPDATA\\nvim-data -NewName $env:LOCALAPPDATA\\nvim-data.bak -ErrorAction SilentlyContinue
+```
+
+2. Clone this repository:
+
+```bash
+# Linux/macOS
+git clone https://github.com/geugenm/nvim-config.git ~/.config/nvim
+
+# Windows (PowerShell)
+git clone https://github.com/geugenm/nvim-config.git $env:LOCALAPPDATA\\nvim
+```
+
+3. Launch Neovim to automatically install plugins:
+
+```bash
 nvim
 ```
 
-## 🏗️ Structure
+The configuration will automatically install [lazy.nvim](https://github.com/folke/lazy.nvim) plugin manager and all required plugins on first launch.
 
-```
-~/.config/nvim
-├── init.lua              -- Entry point
-├── lazy-lock.json        -- Pin exact plugin versions
-├── LICENSE               -- Apache 2.0
-├── lua
-│   ├── config            -- Core: keymaps, options, autocmds, lazy
-│   │   ├── autocmds.lua
-│   │   ├── keymaps.lua
-│   │   ├── lazy.lua      -- Plugin loader + extras
-│   │   ├── options.lua   -- Line endings, indentation, shell
-│   │   └── web_search.lua
-│   └── plugins           -- Plugin specs (one file per domain)
-│       ├── android.lua
-│       ├── clangd.lua
-│       ├── cmake.lua
-│       ├── colortheme.lua
-│       ├── dap_ui.lua
-│       ├── format.lua
-│       ├── gitignore.lua
-│       ├── godbolt.lua
-│       ├── mason_tools.lua
-│       ├── neogen.lua
-│       ├── neotest.lua
-│       ├── overseer.lua
-│       ├── snacks.lua
-│       ├── treesj.lua
-│       └── user.lua
+## C++ Development Environment
+
+### Debugging Setup
+
+#### Windows-Specific Debugging Configuration
+
+To avoid freezes when loading native debug symbols on Windows:
+
+1. Set the `LLDB_USE_NATIVE_PDB_READER` environment variable to prevent the extremely slow symbol loading issue:
+
+```powershell
+# For current session
+$env:LLDB_USE_NATIVE_PDB_READER=1
+
+# Set permanently (run as Administrator)
+[System.Environment]::SetEnvironmentVariable(\"LLDB_USE_NATIVE_PDB_READER\", \"1\", \"Machine\")
 ```
 
-## 🔌 Features
+2. Ensure proper DIA SDK configuration:
+   - Locate `msdia140.dll` in your Visual Studio installation (typically at `[VisualStudioFolder]\\DIA SDK\\bin\\msdia140.dll`)
+   - Add this location to your PATH or copy the DLL to your LLDB installation directory
 
-| Feature | Plugin / Extra | Keymap |
-|---------|---------------|--------|
-| LSP (C/C++) | `clangd` + `clangd_extensions.nvim` | Hover `K`, Rename `<leader>cr` |
-| CMake | `cmake-tools.nvim` + `neocmake` | Build `<leader>cb`, Run `<leader>cr` |
-| Debug | `nvim-dap` + `codelldb` + `nvim-dap-ui` | Toggle breakpoint `<leader>db`, Continue `<leader>dc` |
-| Test (GTest) | `neotest` + `neotest-gtest` | Run nearest `<leader>tt`, Summary `<leader>tS` |
-| Format | `conform.nvim` (`clang-format`, `cmake_format`) | Format `<leader>cf` |
-| Assembly view | `vim-godbolt` | Show asm `<leader>caa`, Pipeline `<leader>cap` |
-| Tasks / Presets | `overseer.nvim` | Task runner `<leader>or` |
-| Doxygen | `neogen` | Generate doc `<leader>cn` |
-| Symbol outline | `aerial.nvim` (LazyVim extra) | Toggle `<leader>cs` |
-| Git diff | `diffview.nvim` (LazyVim extra) | Open `<leader>gd` |
-| Rename preview | `inc-rename.nvim` (LazyVim extra) | `<leader>cr` (live preview) |
+This addresses the common issue where Neovim freezes when loading debug symbols on Windows, significantly improving debugging performance.
 
-## 🛠️ C++ Workflow Tips
+## Python Development Environment
 
-### compile_commands.json
+The configuration includes:
 
-`clangd` needs this file in the project root or build directory.
+- Python language server integration
+- debugpy for debugging Python applications (with proper virtual environment activation)
+- Advanced code completion and refactoring tools
 
-```bash
-# Symlink it so clangd finds it regardless of cwd
-ln -s build/compile_commands.json compile_commands.json
-```
+## Key Features
 
-Or configure CMake:
+- Snake_case naming convention emphasis in code
+- Minimal, laconic code style with maximum library reuse
+- Fast startup and responsive editing experience
+- Optimized for both C++ and Python development workflows
+- Git integration with staging, diffing, and history visualization
+- Error handling that doesn't hide problems
 
-```cmake
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-```
+## Documentation and Resources
 
-### CMake Presets
+- Built upon [LazyVim](https://lazyvim.github.io/) - see their [installation guide](https://lazyvim.github.io/installation)
+- Uses [lazy.nvim](https://github.com/folke/lazy.nvim) for plugin management - see their [documentation](https://lazy.folke.io/installation)
+- Documentation formatted in proper markdown following industry best practices
 
-This config uses `cmake-tools.nvim` with native CMake Presets support. Ensure your repository has `CMakePresets.json` at the project root.
+## Troubleshooting
 
-## 📜 License
+### Known Issues
 
-[Apache 2.0](LICENSE)
+- **nvim-dap debugpy issues on Windows**: Requires proper virtual environment activation before debugging. See [this issue](https://github.com/mfussenegger/nvim-dap-python/issues/118) for details.
+- **Neovim freezes on file reload**: This issue affects Neovim 0.10.x, use stable 0.9.x instead. See [LazyVim issue #1581](https://github.com/LazyVim/LazyVim/issues/1581).
+- **LLDB symbol loading performance**: Set `LLDB_USE_NATIVE_PDB_READER=1` as described above to dramatically improve performance.

--- a/readme.md
+++ b/readme.md
@@ -1,141 +1,202 @@
-# LazyVim Configuration for C++/Python Development
+<div align="center">
 
-A meticulously crafted Neovim configuration optimized for C++ and Python development. This setup provides a clean, efficient editing experience while maintaining excellent performance - designed specifically for developers who value minimal, high-quality tooling.
+# nvim-config
 
-## Installation Guide
+**Professional cross-platform C++ IDE inside Neovim.**
+**CMake-first. Targets: Android, iOS, Linux, Windows, macOS.**
 
-### Prerequisites
+[![Neovim](https://img.shields.io/badge/Neovim-0.10%2B-57A143?logo=neovim&logoColor=white)](https://neovim.io)
+[![Lua](https://img.shields.io/badge/Lua-5.1-2C2D72?logo=lua&logoColor=white)](https://www.lua.org)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
+[![Stars](https://img.shields.io/github/stars/e-gleba/nvim-config?style=social)](https://github.com/e-gleba/nvim-config)
 
-- Neovim 0.9.x (stable version only, avoid pre-release versions)
-- Git
-- C compiler (required for Treesitter functionality)
-- For C++ development: LLDB or GDB
-- For Python development: Python 3.8+ with debugpy
+</div>
 
-### Installing Neovim
+---
 
-#### Linux (Fedora recommended)
+## Target Audience
 
-```bash
-# Fedora
-sudo dnf install neovim
+This configuration is built for **professional cross-platform C++ developers** who work across **Android, iOS, Linux, Windows, and macOS** using **CMake** as the universal build system.
 
-# Ubuntu/Debian
-sudo apt install neovim
-```
+It is designed to be:
+- **AI-agent friendly** -- self-contained, heavily documented, minimal wrapper surface.
+- **Fast** -- zero animation, lazy-loaded everything, native LSP via `clangd`.
+- **Stable** -- upstream defaults first, explicit over clever.
+- **Cross-platform** -- identical experience on every OS.
 
-#### macOS
+## Prerequisites
 
-```bash
-# Using Homebrew (recommended)
-brew install neovim
+| Tool | Purpose | Install |
+|------|---------|---------|
+| [Neovim](https://neovim.io) 0.10+ | Editor | `brew install neovim` / `winget install Neovim.Neovim` |
+| [Git](https://git-scm.com) | Plugin manager | Usually pre-installed |
+| [CMake](https://cmake.org) 3.20+ | Build system | `brew install cmake` / `winget install Kitware.CMake` |
+| [Ninja](https://ninja-build.org) | Fast generator | `brew install ninja` / `choco install ninja` |
+| C++ toolchain | Compiler + debugger | Xcode / MSVC / GCC / Clang |
+| [fzf](https://github.com/junegunn/fzf) | Fuzzy finder | `brew install fzf` / `winget install fzf` |
+| [fd](https://github.com/sharkdp/fd) | Fast file finder | `brew install fd` / `choco install fd` |
+| [ripgrep](https://github.com/BurntSushi/ripgrep) | Fast grep | `brew install ripgrep` / `winget install BurntSushi.ripgrep.MSVC` |
+| [lazygit](https://github.com/jesseduffield/lazygit) | TUI Git client | `brew install lazygit` / `winget install JesseDuffield.lazygit` |
+| Nerd Font | Icons in terminal | [JetBrainsMono Nerd Font](https://github.com/ryanoasis/nerd-fonts/releases/download/v3.2.1/JetBrainsMono.zip) |
 
-# AVOID nightly builds which cause stability issues:
-# brew install --HEAD neovim  # NOT RECOMMENDED
-```
+> **Windows Note:** `clangd` and `codelldb` are installed automatically via [Mason](https://github.com/williamboman/mason.nvim). If you see PDB errors during native debugging, enable **Edit and Continue** in Visual Studio or set the environment variable `LLDB_USE_NATIVE_PDB_READER=1` before launching Neovim.
 
-#### Windows
+> **Line endings:** This repository enforces LF via [`.gitattributes`](.gitattributes). If you still see CRLF warnings from `cmake-language-server`, ensure Git is not overriding with `core.autocrlf=true`:
+> ```bash
+> git config --global core.autocrlf false
+> ```
 
-**Recommended approach**: Use Windows Subsystem for Linux (WSL2) with Ubuntu.
+## Quick Start
 
-For native Windows:
-
-- Download the MSI installer from [Neovim Releases](https://github.com/neovim/neovim/releases)
-- Or use a package manager:
-
-  ```powershell
-  # Scoop
-  scoop install neovim
-  ```
-
-**Important**: On Windows, you'll need to install a C compiler for Treesitter support following the [nvim-treesitter documentation](https://github.com/nvim-treesitter/nvim-treesitter#windows-installation).
-
-### Setting Up This Configuration
-
-1. First, backup any existing Neovim configuration:
+### Linux / macOS
 
 ```bash
-# Linux/macOS
-mkdir -p ~/.config/nvim.bak
-mv ~/.config/nvim ~/.config/nvim.bak/
-mv ~/.local/share/nvim ~/.local/share/nvim.bak
-mv ~/.local/state/nvim ~/.local/state/nvim.bak
-mv ~/.cache/nvim ~/.cache/nvim.bak
+# 1. Back up existing config
+mv ~/.config/nvim ~/.config/nvim.bak.$(date +%s)
+mv ~/.local/share/nvim ~/.local/share/nvim.bak.$(date +%s)
+mv ~/.local/state/nvim ~/.local/state/nvim.bak.$(date +%s)
+mv ~/.cache/nvim ~/.cache/nvim.bak.$(date +%s)
 
-# Windows (PowerShell)
-Rename-Item -Path $env:LOCALAPPDATA\\nvim -NewName $env:LOCALAPPDATA\\nvim.bak -ErrorAction SilentlyContinue
-Rename-Item -Path $env:LOCALAPPDATA\\nvim-data -NewName $env:LOCALAPPDATA\\nvim-data.bak -ErrorAction SilentlyContinue
-```
+# 2. Clone
+git clone https://github.com/e-gleba/nvim-config.git ~/.config/nvim
 
-2. Clone this repository:
-
-```bash
-# Linux/macOS
-git clone https://github.com/geugenm/nvim-config.git ~/.config/nvim
-
-# Windows (PowerShell)
-git clone https://github.com/geugenm/nvim-config.git $env:LOCALAPPDATA\\nvim
-```
-
-3. Launch Neovim to automatically install plugins:
-
-```bash
+# 3. Launch -- plugins install automatically
 nvim
 ```
 
-The configuration will automatically install [lazy.nvim](https://github.com/folke/lazy.nvim) plugin manager and all required plugins on first launch.
-
-## C++ Development Environment
-
-### Debugging Setup
-
-#### Windows-Specific Debugging Configuration
-
-To avoid freezes when loading native debug symbols on Windows:
-
-1. Set the `LLDB_USE_NATIVE_PDB_READER` environment variable to prevent the extremely slow symbol loading issue:
+### Windows (PowerShell)
 
 ```powershell
-# For current session
-$env:LLDB_USE_NATIVE_PDB_READER=1
+# 1. Back up existing config
+$ts = Get-Date -Format "yyyyMMddHHmmss"
+Rename-Item -Path $env:LOCALAPPDATA\nvim -NewName "nvim.bak.$ts" -ErrorAction SilentlyContinue
+Rename-Item -Path $env:LOCALAPPDATA\nvim-data -NewName "nvim-data.bak.$ts" -ErrorAction SilentlyContinue
+Rename-Item -Path $env:LOCALAPPDATA\nvim-state -NewName "nvim-state.bak.$ts" -ErrorAction SilentlyContinue
+Rename-Item -Path $env:LOCALAPPDATA\nvim-cache -NewName "nvim-cache.bak.$ts" -ErrorAction SilentlyContinue
 
-# Set permanently (run as Administrator)
-[System.Environment]::SetEnvironmentVariable(\"LLDB_USE_NATIVE_PDB_READER\", \"1\", \"Machine\")
+# 2. Clone
+git clone https://github.com/e-gleba/nvim-config.git $env:LOCALAPPDATA\nvim
+
+# 3. Launch
+nvim
 ```
 
-2. Ensure proper DIA SDK configuration:
-   - Locate `msdia140.dll` in your Visual Studio installation (typically at `[VisualStudioFolder]\\DIA SDK\\bin\\msdia140.dll`)
-   - Add this location to your PATH or copy the DLL to your LLDB installation directory
+### macOS Warning: Do NOT install nightly
 
-This addresses the common issue where Neovim freezes when loading debug symbols on Windows, significantly improving debugging performance.
+```bash
+# AVOID -- causes file-reload freezes documented in LazyVim issue #1581
+brew install --HEAD neovim   # NOT RECOMMENDED
+```
 
-## Python Development Environment
+## Working with Native IDEs
 
-The configuration includes:
+This config is designed to coexist with platform-native IDEs. You edit C++ in Neovim; you package and deploy in the native IDE.
 
-- Python language server integration
-- debugpy for debugging Python applications (with proper virtual environment activation)
-- Advanced code completion and refactoring tools
+| Platform | Native IDE | Workflow |
+|----------|-----------|----------|
+| Android | [Android Studio](https://developer.android.com/studio) | Neovim edits `CMakeLists.txt` / `.cpp`; Android Studio builds APK via Gradle. |
+| iOS | [Xcode](https://developer.apple.com/xcode/) | Neovim edits sources; Xcode builds/deploys to device via generated `.xcodeproj`. |
+| Windows | [Visual Studio](https://visualstudio.microsoft.com/) / [CLion](https://www.jetbrains.com/clion/) | Neovim edits; IDE handles MSVC toolchain / PDB symbols. |
+| Linux | Any (Qt Creator, CLion, VS Code) | Neovim is the editor; use native debugger or terminal for deploy. |
 
-## Key Features
+**Windows PowerShell tip -- open current file in Android Studio or CLion:**
 
-- Snake_case naming convention emphasis in code
-- Minimal, laconic code style with maximum library reuse
-- Fast startup and responsive editing experience
-- Optimized for both C++ and Python development workflows
-- Git integration with staging, diffing, and history visualization
-- Error handling that doesn't hide problems
+```powershell
+# From inside Neovim terminal (:terminal)
+# Open Android Studio at current project root
+& "C:\Program Files\Android\Android Studio\bin\studio64.exe" $(git rev-parse --show-toplevel)
 
-## Documentation and Resources
+# Or open CLion at current file
+& "C:\Program Files\JetBrains\CLion Nova\bin\clion64.exe" --line $(nvim --headless -c 'echo line(".")' -c 'q!' 2>$null) $env:NVIM_FILE
+```
 
-- Built upon [LazyVim](https://lazyvim.github.io/) - see their [installation guide](https://lazyvim.github.io/installation)
-- Uses [lazy.nvim](https://github.com/folke/lazy.nvim) for plugin management - see their [documentation](https://lazy.folke.io/installation)
-- Documentation formatted in proper markdown following industry best practices
+**macOS tip -- open Xcode from Neovim terminal:**
+
+```bash
+# Open generated Xcode project
+open build/MyProject.xcodeproj
+```
+
+## Structure
+
+```
+~/.config/nvim
+├── init.lua              -- Entry point
+├── lazy-lock.json        -- Pin exact plugin versions
+├── LICENSE               -- Apache 2.0
+├── lua
+│   ├── config            -- Core: keymaps, options, autocmds, lazy
+│   │   ├── autocmds.lua
+│   │   ├── keymaps.lua
+│   │   ├── lazy.lua      -- Plugin loader + extras
+│   │   ├── options.lua   -- Line endings, indentation, shell
+│   │   └── web_search.lua
+│   └── plugins           -- Plugin specs (one file per domain)
+│       ├── android.lua
+│       ├── clangd.lua
+│       ├── cmake.lua
+│       ├── colortheme.lua
+│       ├── dap_ui.lua
+│       ├── format.lua
+│       ├── gitignore.lua
+│       ├── godbolt.lua
+│       ├── mason_tools.lua
+│       ├── neogen.lua
+│       ├── neotest.lua
+│       ├── overseer.lua
+│       ├── snacks.lua
+│       ├── treesj.lua
+│       └── user.lua
+```
+
+## Features
+
+| Feature | Plugin / Extra | Keymap |
+|---------|---------------|--------|
+| LSP (C/C++) | `clangd` + `clangd_extensions.nvim` | Hover `K`, Rename `<leader>cr` |
+| CMake | `cmake-tools.nvim` + `neocmake` | Build `<leader>cb`, Run `<leader>cr` |
+| Debug | `nvim-dap` + `codelldb` + `nvim-dap-ui` | Toggle breakpoint `<leader>db`, Continue `<leader>dc` |
+| Test (GTest) | `neotest` + `neotest-gtest` | Run nearest `<leader>tt`, Summary `<leader>tS` |
+| Format | `conform.nvim` (`clang-format`, `cmake_format`) | Format `<leader>cf` |
+| Assembly view | `vim-godbolt` | Show asm `<leader>caa`, Pipeline `<leader>cap` |
+| Tasks / Presets | `overseer.nvim` | Task runner `<leader>or` |
+| Doxygen | `neogen` | Generate doc `<leader>cn` |
+| Symbol outline | `aerial.nvim` (LazyVim extra) | Toggle `<leader>cs` |
+| Git diff | `diffview.nvim` (LazyVim extra) | Open `<leader>gd` |
+| Rename preview | `inc-rename.nvim` (LazyVim extra) | `<leader>cr` (live preview) |
+
+## C++ Workflow Tips
+
+### compile_commands.json
+
+`clangd` needs this file in the project root or build directory.
+
+```bash
+# Symlink it so clangd finds it regardless of cwd
+ln -s build/compile_commands.json compile_commands.json
+```
+
+Or configure CMake:
+
+```cmake
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+```
+
+### CMake Presets
+
+This config uses `cmake-tools.nvim` with native CMake Presets support. Ensure your repository has `CMakePresets.json` at the project root.
 
 ## Troubleshooting
 
-### Known Issues
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `cmake-language-server` reports "invalid line endings" | CRLF on disk (Git `core.autocrlf=true`) | `git config --global core.autocrlf false`, re-clone repo |
+| Neovim freezes on file reload | Neovim 0.10.x nightly bug | Use stable 0.10.x release, not HEAD. See [LazyVim #1581](https://github.com/LazyVim/LazyVim/issues/1581) |
+| Debug symbols load slowly on Windows | LLDB using old DIA reader | Set `$env:LLDB_USE_NATIVE_PDB_READER=1` permanently |
+| `nvim-dap-python` fails on Windows | Virtual environment not activated | Activate venv before launching Neovim. See [nvim-dap-python #118](https://github.com/mfussenegger/nvim-dap-python/issues/118) |
+| Missing icons / garbled glyphs | Terminal lacks Nerd Font | Install [JetBrainsMono Nerd Font](https://github.com/ryanoasis/nerd-fonts/releases/download/v3.2.1/JetBrainsMono.zip) and set terminal font |
+| `fzf` / `fd` / `rg` not found | Tools not in PATH | Install via package manager (see Prerequisites table) |
 
-- **nvim-dap debugpy issues on Windows**: Requires proper virtual environment activation before debugging. See [this issue](https://github.com/mfussenegger/nvim-dap-python/issues/118) for details.
-- **Neovim freezes on file reload**: This issue affects Neovim 0.10.x, use stable 0.9.x instead. See [LazyVim issue #1581](https://github.com/LazyVim/LazyVim/issues/1581).
-- **LLDB symbol loading performance**: Set `LLDB_USE_NATIVE_PDB_READER=1` as described above to dramatically improve performance.
+## License
+
+[Apache 2.0](LICENSE)


### PR DESCRIPTION
## What changed

### README (`readme.md`)
- **Restored accidentally removed content** from the pre-cleaning version: PowerShell backup/clone commands, Windows native install (MSI/Scoop), `LLDB_USE_NATIVE_PDB_READER` env var, DIA SDK note, "no nightly builds" warning, and full Troubleshooting section.
- **Added Required Tools table**: `fzf`, `fd`, `ripgrep`, `lazygit`, Nerd Font — with per-OS install commands.
- **Added "Working with Native IDEs" section**: explains how to use Neovim alongside Android Studio, Xcode, and CLion / Visual Studio on each platform. Includes PowerShell snippets for opening the current project in Android Studio or CLion from the Neovim terminal.
- Kept the clean centered badge header, feature matrix, structure tree, and `compile_commands.json` tips.

### Options (`lua/config/options.lua`)
- **Hardened LF enforcement**: changed `fileformats = 'unix,dos'` → `fileformats = 'unix'` (no dos fallback). Neovim never attempts DOS detection; literal `\r` stays in the buffer and is stripped by the autocmd. This prevents the intermittent `fileformat=dos` detection that forced manual `:set ff=unix`.
- **Unconditional `\r` stripping**: removed the `search('\r')` guard. The old guard could miss hidden `\r` or race with LSP attach. The substitution is fast enough to run on every buffer read.
- **Added `FilterReadPost`**: catches `:=`, `:r`, and other insert paths that bypass `BufReadPost`.
- **Added `buftype` guard**: skips terminal, quickfix, help, and other special buffers.
- **Explicit buffer scoping**: `vim.bo[args.buf]` instead of global `vim.bo` to avoid cross-buffer pollution.

### Doc links preserved
Every option and troubleshooting row still has inline markdown links to upstream documentation (neovim.io, git-scm.com, GitHub issues).