### PR TITLE
fix(options): bulletproof LF enforcement + top-tier readme

### DIFF
--- a/lua/config/options.lua
+++ b/lua/config/options.lua
@@ -7,9 +7,20 @@ local g = vim.g
 local is_win = vim.fn.has('win32') == 1
 
 -- Encoding
--- `fileencoding` (written to disk) defaults to UTF-8 in Neovim, but be explicit.
+-- `fileencoding` (written to disk) defaults to UTF-8 in Neovim; be explicit.
 -- https://neovim.io/doc/user/options.html#'fileencoding'
 opt.fileencoding = 'utf-8'
+
+-- BOM (Byte Order Mark) -- never write it. BOM breaks shebangs, CMake,
+-- and many C++ compilers / LSPs.
+-- https://neovim.io/doc/user/options.html#'bomb'
+opt.bomb = false
+
+-- Modeline -- disable entirely. A `vim:ff=dos:` modeline in a third-party
+-- header silently overrides our line-ending policy.
+-- https://neovim.io/doc/user/options.html#'modeline'
+opt.modeline = false
+opt.modelines = 0
 
 -- Line endings -- force LF everywhere, unconditionally.
 -- On Windows Git may check out CRLF (`core.autocrlf=true`), and LSPs
@@ -25,9 +36,8 @@ opt.fileencoding = 'utf-8'
 --      https://neovim.io/doc/user/options.html#'fileformat'
 --   4. `fixendofline = true` -- POSIX-compliant trailing newline on write.
 --      https://neovim.io/doc/user/options.html#'fixendofline'
---   5. After read: strip literal `\r` left by `fileformats=unix`.
---      Pure Lua -- no vim.cmd string escaping, no winrestview fragility.
---   6. Before write: reaffirm `unix` so plugins cannot flip to dos.
+--   5. `endofline = true` -- buffer always claims to end with a newline.
+--      https://neovim.io/doc/user/options.html#'endofline'
 --
 -- https://git-scm.com/docs/gitattributes#_end_of_line_conversion
 
@@ -36,41 +46,61 @@ vim.g.editorconfig = false
 opt.fileformats = 'unix'
 opt.fileformat = 'unix'
 opt.fixendofline = true
+opt.endofline = true
 
 local force_lf_au = vim.api.nvim_create_augroup('ForceLf', { clear = true })
 
--- After reading a file: strip stray carriage returns.
--- When Git checks out CRLF on Windows, Neovim reads as unix format
--- and the `\r` stays as a literal trailing character. We remove it
--- with a pure Lua loop so LSPs never see DOS line endings.
+-- After reading any file: strip every carriage return, lock to unix,
+-- and clear the modified flag. We do this unconditionally so a plugin
+-- or modeline that snuck in during read is overwritten.
 vim.api.nvim_create_autocmd('BufReadPost', {
     group = force_lf_au,
     pattern = '*',
     callback = function(args)
-        if vim.bo[args.buf].buftype ~= '' then
+        local bo = vim.bo[args.buf]
+        if bo.buftype ~= '' or bo.binary then
             return
         end
         local lines = vim.api.nvim_buf_get_lines(args.buf, 0, -1, false)
         local dirty = false
         for i, line in ipairs(lines) do
-            if line:sub(-1) == '\r' then
-                lines[i] = line:sub(1, -2)
+            if line:find('\r', 1, true) then
+                lines[i] = line:gsub('\r', '')
                 dirty = true
             end
         end
         if dirty then
             vim.api.nvim_buf_set_lines(args.buf, 0, -1, false, lines)
-            vim.bo[args.buf].fileformat = 'unix'
+            bo.modified = false
         end
+        bo.fileformat = 'unix'
     end,
 })
 
--- Before every write: lock to LF.
+-- New empty buffers: start in LF mode.
+vim.api.nvim_create_autocmd('BufNewFile', {
+    group = force_lf_au,
+    pattern = '*',
+    callback = function(args)
+        vim.bo[args.buf].fileformat = 'unix'
+    end,
+})
+
+-- Before every write: reaffirm unix so plugins cannot flip to dos.
 vim.api.nvim_create_autocmd('BufWritePre', {
     group = force_lf_au,
     pattern = '*',
     callback = function(args)
         vim.bo[args.buf].fileformat = 'unix'
+    end,
+})
+
+-- After full startup: stomp any plugin that reset fileformats behind us.
+vim.api.nvim_create_autocmd('VimEnter', {
+    group = force_lf_au,
+    once = true,
+    callback = function()
+        vim.opt.fileformats = 'unix'
     end,
 })
 

--- a/readme.md
+++ b/readme.md
@@ -26,29 +26,93 @@ It is designed to be:
 
 ## Prerequisites
 
-| Tool | Purpose | Install |
-|------|---------|---------|
-| [Neovim](https://neovim.io) 0.10+ | Editor | `brew install neovim` / `winget install Neovim.Neovim` |
-| [Git](https://git-scm.com) | Plugin manager | Usually pre-installed |
-| [CMake](https://cmake.org) 3.20+ | Build system | `brew install cmake` / `winget install Kitware.CMake` |
-| [Ninja](https://ninja-build.org) | Fast generator | `brew install ninja` / `choco install ninja` |
-| C++ toolchain | Compiler + debugger | Xcode / MSVC / GCC / Clang |
-| [fzf](https://github.com/junegunn/fzf) | Fuzzy finder | `brew install fzf` / `winget install fzf` |
-| [fd](https://github.com/sharkdp/fd) | Fast file finder | `brew install fd` / `choco install fd` |
-| [ripgrep](https://github.com/BurntSushi/ripgrep) | Fast grep | `brew install ripgrep` / `winget install BurntSushi.ripgrep.MSVC` |
-| [lazygit](https://github.com/jesseduffield/lazygit) | TUI Git client | `brew install lazygit` / `winget install JesseDuffield.lazygit` |
+### macOS
+
+```bash
+brew install neovim git cmake ninja fzf fd ripgrep lazygit
+```
+
+### Linux (apt)
+
+```bash
+sudo apt update && sudo apt install -y neovim git cmake ninja-build fzf fd-find ripgrep
+# lazygit: follow https://github.com/jesseduffield/lazygit?tab=readme-ov-file#ubuntu
+```
+
+### Windows -- Scoop (recommended)
+
+```powershell
+# Install scoop (run once)
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression
+
+# Install everything in one shot
+scoop install neovim git cmake ninja llvm fzf fd ripgrep lazygit
+```
+
+> **If you prefer winget / chocolatey:**
+> ```powershell
+> winget install Neovim.Neovim Kitware.CMake JernejSimoncic.Fzf sharkdp.Fd BurntSushi.Ripgrep.MSVC JesseDuffield.lazygit
+> choco install neovim cmake ninja fzf fd ripgrep lazygit
+> ```
+
+### All platforms
+
+| Requirement | Purpose | Check command |
+|-------------|---------|---------------|
+| [Neovim](https://neovim.io) 0.10+ stable | Editor | `nvim --version` |
+| [Git](https://git-scm.com) | Plugin manager | `git --version` |
+| [CMake](https://cmake.org) 3.20+ | Build system | `cmake --version` |
+| [Ninja](https://ninja-build.org) | Fast generator | `ninja --version` |
+| C++ toolchain | Compiler + debugger | `clang++ --version` / `cl` / `g++` |
+| [fzf](https://github.com/junegunn/fzf) | Fuzzy finder | `fzf --version` |
+| [fd](https://github.com/sharkdp/fd) | Fast file finder | `fd --version` |
+| [ripgrep](https://github.com/BurntSushi/ripgrep) | Fast grep | `rg --version` |
+| [lazygit](https://github.com/jesseduffield/lazygit) | TUI Git client | `lazygit --version` |
 | Nerd Font | Icons in terminal | [JetBrainsMono Nerd Font](https://github.com/ryanoasis/nerd-fonts/releases/download/v3.2.1/JetBrainsMono.zip) |
 
-> **Windows Note:** `clangd` and `codelldb` are installed automatically via [Mason](https://github.com/williamboman/mason.nvim). If you see PDB errors during native debugging, enable **Edit and Continue** in Visual Studio or set the environment variable `LLDB_USE_NATIVE_PDB_READER=1` before launching Neovim.
-
-> **Line endings:** This repository enforces LF via [`.gitattributes`](.gitattributes). If you still see CRLF warnings from `cmake-language-server`, ensure Git is not overriding with `core.autocrlf=true`:
+> **Nightly warning (macOS):** Do NOT install Neovim nightly. It causes file-reload freezes. See [LazyVim #1581](https://github.com/LazyVim/LazyVim/issues/1581).
 > ```bash
-> git config --global core.autocrlf false
+> brew install neovim        # OK
+> brew install --HEAD neovim # NOT OK
+> ```
+
+## Windows Environment Variables
+
+Some Windows-specific environment variables are required for debugging and line-ending sanity.
+
+### LLDB / CodeLLDB PDB support
+
+CodeLLDB on Windows needs the native PDB reader to debug MSVC binaries. Set this **permanently** (recommended) or per-session.
+
+```powershell
+# Permanent -- persists across reboots
+[Environment]::SetEnvironmentVariable("LLDB_USE_NATIVE_PDB_READER", "1", "User")
+
+# Current session only
+$env:LLDB_USE_NATIVE_PDB_READER = "1"
+```
+
+### Line endings -- force LF in Git
+
+Neovim and LSPs require LF. Prevent Git from converting to CRLF on checkout:
+
+```powershell
+# Global -- affects all repositories
+[Environment]::SetEnvironmentVariable("GIT_LFS_PATH", "$env:USERPROFILE\scoop\apps\git-lfs\current", "User")
+git config --global core.autocrlf false
+git config --global core.eol lf
+```
+
+> If you already cloned a repo with CRLF, force-reset line endings:
+> ```bash
+> git rm --cached -r .
+> git reset --hard
 > ```
 
 ## Quick Start
 
-### Linux / macOS
+### macOS / Linux
 
 ```bash
 # 1. Back up existing config
@@ -79,13 +143,6 @@ git clone https://github.com/e-gleba/nvim-config.git $env:LOCALAPPDATA\nvim
 
 # 3. Launch
 nvim
-```
-
-### macOS Warning: Do NOT install nightly
-
-```bash
-# AVOID -- causes file-reload freezes documented in LazyVim issue #1581
-brew install --HEAD neovim   # NOT RECOMMENDED
 ```
 
 ## Working with Native IDEs
@@ -190,12 +247,12 @@ This config uses `cmake-tools.nvim` with native CMake Presets support. Ensure yo
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| `cmake-language-server` reports "invalid line endings" | CRLF on disk (Git `core.autocrlf=true`) | `git config --global core.autocrlf false`, re-clone repo |
+| `cmake-language-server` reports "invalid line endings" | CRLF on disk (Git `core.autocrlf=true`) | See [Windows Environment Variables](#windows-environment-variables) section above; re-clone with `core.autocrlf=false` |
 | Neovim freezes on file reload | Neovim 0.10.x nightly bug | Use stable 0.10.x release, not HEAD. See [LazyVim #1581](https://github.com/LazyVim/LazyVim/issues/1581) |
-| Debug symbols load slowly on Windows | LLDB using old DIA reader | Set `$env:LLDB_USE_NATIVE_PDB_READER=1` permanently |
+| Debug symbols load slowly on Windows | LLDB using old DIA reader | Run `[Environment]::SetEnvironmentVariable("LLDB_USE_NATIVE_PDB_READER", "1", "User")` and restart Neovim |
 | `nvim-dap-python` fails on Windows | Virtual environment not activated | Activate venv before launching Neovim. See [nvim-dap-python #118](https://github.com/mfussenegger/nvim-dap-python/issues/118) |
 | Missing icons / garbled glyphs | Terminal lacks Nerd Font | Install [JetBrainsMono Nerd Font](https://github.com/ryanoasis/nerd-fonts/releases/download/v3.2.1/JetBrainsMono.zip) and set terminal font |
-| `fzf` / `fd` / `rg` not found | Tools not in PATH | Install via package manager (see Prerequisites table) |
+| `fzf` / `fd` / `rg` not found | Tools not in PATH | Add scoop / brew / apt bin directory to PATH, or reinstall |
 
 ## License
 


### PR DESCRIPTION
Closes the "always need to manually `:set ff=unix`" problem and provides copy-paste Windows setup.

### `options.lua` changes

| Problem | Fix |
|---------|-----|
| Modeline in a file (`vim:ff=dos:`) silently overrode `unix` | `modeline = false` |
| BOM in UTF-8 files broke CMake / LSP parsers | `bomb = false` |
| Only trailing `\r` stripped; mid-line `\r` missed | `gsub('\r', '')` on ALL lines |
| `fileformat = 'unix'` only set when `dirty=true`; sometimes `ff` stayed `dos` | Now set **unconditionally** after every `BufReadPost` |
| Buffer marked `[+]` modified after opening a CRLF file | `modified = false` after stripping (semantic content unchanged) |
| New empty buffers inherited `ff=dos` on Windows | Added `BufNewFile` autocmd |
| Some plugin resets `fileformats` after startup | Added `VimEnter` autocmd to stomp it back to `'unix'` |

### `readme.md` changes

- **Scoop is now the primary Windows path** — one-liner install for all tools
- **Copy-paste PowerShell env vars** — `LLDB_USE_NATIVE_PDB_READER=1` permanent + current session
- **Copy-paste Git LF config** — `core.autocrlf false` + `core.eol lf`
- **CRLF recovery** — `git rm --cached -r . && git reset --hard` for already-cloned repos
- macOS / Linux remain single-line `brew` / `apt` commands

No new plugins. Zero wrapper bloat. All links in comments point to upstream docs.

### References

- [Neovim options: modeline](https://neovim.io/doc/user/options.html#'modeline')
- [Neovim options: bomb](https://neovim.io/doc/user/options.html#'bomb')
- [Neovim options: fileformats](https://neovim.io/doc/user/options.html#'fileformats')
- [Neovim options: fileformat](https://neovim.io/doc/user/options.html#'fileformat')
- [Git core.autocrlf](https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreautocrlf)
- [Git core.eol](https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreeol)