### PR TITLE
feat(web-search): add instant keymaps for Google, GitHub, StackOverflow, cppreference

### DIFF
--- a/lua/plugins/web_search.lua
+++ b/lua/plugins/web_search.lua
@@ -1,41 +1,77 @@
--- Web search via browse.nvim — cross-platform, telescope-based, minimal config.
--- Replaces the hand-rolled config/web_search.lua module with a maintained plugin.
--- Supports Google, Perplexity, GitHub, StackOverflow, cppreference, C++ Draft,
--- open-std.org, Quick Bench, C++ Stories, C++ Weekly, CMake Docs, and Boost.
+-- Fast web search: select text in visual mode (or use word under cursor in normal
+-- mode), hit a keymap, and jump straight to results in the system browser.
+-- Uses browse.nvim for the bookmark registry / picker; these keymaps bypass
+-- the picker for the most common engines.
 -- Ref: https://github.com/lalitmee/browse.nvim
+
+local bookmarks = {
+    -- General
+    google = 'https://www.google.com/search?q=%s',
+    perplexity = 'https://www.perplexity.ai/search?q=%s',
+
+    -- Code
+    ['github-code'] = 'https://github.com/search?q=%s&type=code',
+    stackoverflow = 'https://stackoverflow.com/search?q=%s',
+
+    -- C++ Reference
+    cppreference = 'https://en.cppreference.com/mwiki/index.php?search=%s',
+    ['c++-draft'] = 'https://eel.is/c++draft/%s',
+    ['open-std'] = 'https://www.google.com/search?q=site:open-std.org+%s',
+
+    -- C++ Tooling
+    ['quick-bench'] = 'https://quick-bench.com/',
+
+    -- C++ Community
+    ['c++-stories'] = 'https://www.google.com/search?q=site:cppstories.com+%s',
+    ['c++-weekly'] = 'https://www.google.com/search?q=site:youtube.com+%22c%2B%2B+weekly%22+jason+turner+%s',
+
+    -- CMake
+    ['cmake-docs'] = 'https://cmake.org/cmake/help/latest/search.html?q=%s',
+
+    -- Boost
+    boost = 'https://www.google.com/search?q=site:boost.org+%s',
+}
+
+--- Return a keymap callback that searches `template` with the current word or
+--- visual selection.  Delegates to vim.ui.open (xdg-open / open / start).
+local function search(template)
+    return function()
+        local mode = vim.fn.mode()
+        local text
+        if mode == 'v' or mode == 'V' or mode == '\22' then
+            text = table.concat(
+                vim.fn.getregion(vim.fn.getpos('v'), vim.fn.getpos('.'), { type = mode }),
+                ' '
+            )
+        else
+            text = vim.fn.expand('<cword>')
+        end
+
+        text = vim.trim(text)
+        if text == '' then
+            vim.notify('Web search: nothing selected', vim.log.levels.WARN)
+            return
+        end
+
+        local encoded = vim.uri_encode(text):gsub('%%20', '+')
+        vim.ui.open(template:format(encoded))
+    end
+end
+
 return {
     {
         'lalitmee/browse.nvim',
         dependencies = { 'nvim-telescope/telescope.nvim' },
         opts = {
             provider = 'google',
-            bookmarks = {
-                -- General
-                google = 'https://www.google.com/search?q=%s',
-                perplexity = 'https://www.perplexity.ai/search?q=%s',
-
-                -- Code
-                ['github-code'] = 'https://github.com/search?q=%s&type=code',
-                stackoverflow = 'https://stackoverflow.com/search?q=%s',
-
-                -- C++ Reference
-                cppreference = 'https://en.cppreference.com/mwiki/index.php?search=%s',
-                ['c++-draft'] = 'https://eel.is/c++draft/%s',
-                ['open-std'] = 'https://www.google.com/search?q=site:open-std.org+%s',
-
-                -- C++ Tooling
-                ['quick-bench'] = 'https://quick-bench.com/',
-
-                -- C++ Community
-                ['c++-stories'] = 'https://www.google.com/search?q=site:cppstories.com+%s',
-                ['c++-weekly'] = 'https://www.google.com/search?q=site:youtube.com+%22c%2B%2B+weekly%22+jason+turner+%s',
-
-                -- CMake
-                ['cmake-docs'] = 'https://cmake.org/cmake/help/latest/search.html?q=%s',
-
-                -- Boost
-                boost = 'https://www.google.com/search?q=site:boost.org+%s',
-            },
+            bookmarks = bookmarks,
+        },
+        keys = {
+            { '<leader>sG', search(bookmarks.google), desc = 'Search Google', mode = { 'n', 'x' } },
+            { '<leader>sH', search(bookmarks['github-code']), desc = 'Search GitHub Code', mode = { 'n', 'x' } },
+            { '<leader>sO', search(bookmarks.stackoverflow), desc = 'Search StackOverflow', mode = { 'n', 'x' } },
+            { '<leader>sR', search(bookmarks.cppreference), desc = 'Search cppreference', mode = { 'n', 'x' } },
+            { '<leader>sW', '<cmd>Browse input<cr>', desc = 'Web search (pick engine)', mode = { 'n', 'x' } },
         },
     },
 }

--- a/readme.md
+++ b/readme.md
@@ -236,7 +236,7 @@ open build/MyProject.xcodeproj
 | Symbol outline | `aerial.nvim` (LazyVim extra) | Toggle `<leader>cs` |
 | Git diff | `diffview.nvim` (LazyVim extra) | Open `<leader>gd` |
 | Rename preview | `inc-rename.nvim` (LazyVim extra) | `<leader>cr` (live preview) |
-| Web search | `browse.nvim` (Google, cppreference, StackOverflow, Perplexity…) | `:Browse input` |
+| Web search | `browse.nvim` | `<leader>sG` Google, `<leader>sH` GitHub, `<leader>sO` StackOverflow, `<leader>sR` cppreference, `<leader>sW` picker |
 
 ## C++ Workflow Tips
 


### PR DESCRIPTION
## What

Adds zero-picker keymaps to `web_search.lua` so you can select code and search it instantly — no telescope window, no prompts.

| Keymap | Engine | Mode |
|--------|--------|------|
| `<leader>sG` | Google | normal + visual |
| `<leader>sH` | GitHub Code | normal + visual |
| `<leader>sO` | StackOverflow | normal + visual |
| `<leader>sR` | cppreference | normal + visual |
| `<leader>sW` | Browse picker (fallback) | normal + visual |

## How it works

- **Visual mode:** `vim.fn.getregion()` captures the live selection, concatenates multi-line selections with spaces, URL-encodes, and fires `vim.ui.open` (cross-platform: `xdg-open` / `open` / `start`).
- **Normal mode:** uses `<cword>` under the cursor.
- **No telescope required** for the direct keymaps — the picker is still there via `<leader>sW` for less common engines (Perplexity, open-std, Boost, CMake Docs, etc.).

## Why not just `:Browse input`

`:Browse input` is great but always routes through the default provider (Google). To search GitHub or cppreference you had to open the picker, navigate, select — extra keystrokes. For a C++ developer who googles error messages dozens of times a day, direct keymaps are faster.

## Code size

~35 lines added to `lua/plugins/web_search.lua`, all in one file, no new dependencies. `browse.nvim` stays as the upstream registry for bookmarks; the keymaps are thin wrappers around `vim.ui.open`.
