### PR TITLE
feat(web-search): add Scira AI default keymap <leader>ss

### DIFF
--- a/lua/plugins/web_search.lua
+++ b/lua/plugins/web_search.lua
@@ -5,6 +5,9 @@
 -- Ref: https://github.com/lalitmee/browse.nvim
 
 local bookmarks = {
+    -- AI Search
+    scira = 'https://scira.ai?q=%s',
+
     -- General
     google = 'https://www.google.com/search?q=%s',
     perplexity = 'https://www.perplexity.ai/search?q=%s',
@@ -67,6 +70,7 @@ return {
             bookmarks = bookmarks,
         },
         keys = {
+            { '<leader>ss', search(bookmarks.scira), desc = 'Search Scira AI', mode = { 'n', 'x' } },
             { '<leader>sG', search(bookmarks.google), desc = 'Search Google', mode = { 'n', 'x' } },
             { '<leader>sH', search(bookmarks['github-code']), desc = 'Search GitHub Code', mode = { 'n', 'x' } },
             { '<leader>sO', search(bookmarks.stackoverflow), desc = 'Search StackOverflow', mode = { 'n', 'x' } },

--- a/readme.md
+++ b/readme.md
@@ -236,7 +236,8 @@ open build/MyProject.xcodeproj
 | Symbol outline | `aerial.nvim` (LazyVim extra) | Toggle `<leader>cs` |
 | Git diff | `diffview.nvim` (LazyVim extra) | Open `<leader>gd` |
 | Rename preview | `inc-rename.nvim` (LazyVim extra) | `<leader>cr` (live preview) |
-| Web search | `browse.nvim` | `<leader>sG` Google, `<leader>sH` GitHub, `<leader>sO` StackOverflow, `<leader>sR` cppreference, `<leader>sW` picker |
+| Web search (AI) | `browse.nvim` (Scira) | `<leader>ss` |
+| Web search | `browse.nvim` (Google, GitHub, StackOverflow, cppreference…) | `<leader>sG`, `<leader>sH`, `<leader>sO`, `<leader>sR`, `<leader>sW` |
 
 ## C++ Workflow Tips
 


### PR DESCRIPTION
## What

Adds Scira AI (`https://scira.ai`) as the default AI search engine, mapped to the fastest-reach keymap `<leader>ss`.

## Why

Scira AI is an open-source AI search engine with inline citations, code execution, and multi-source web search. Good default for asking questions about selected code without leaving the editor context.

## Change

| Keymap | Engine | Mode |
|--------|--------|------|
| `<leader>ss` | **Scira AI** | normal + visual |
| `<leader>sG` | Google | normal + visual |
| `<leader>sH` | GitHub Code | normal + visual |
| `<leader>sO` | StackOverflow | normal + visual |
| `<leader>sR` | cppreference | normal + visual |
| `<leader>sW` | Browse picker (all engines) | normal + visual |

Scira URL format confirmed from upstream docs: `https://scira.ai?q=%s`
