### PR TITLE
style(repo): redesign README, switch to MIT, add linguist hints

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,8 +14,8 @@
 *.hpp   text eol=lf
 *.cmake text eol=lf
 CMakeLists.txt text eol=lf
-*.lua   text eol=lf
-*.md    text eol=lf
+*.lua   text eol=lf linguist-language=Lua
+*.md    text eol=lf linguist-documentation
 *.json  text eol=lf
 *.toml  text eol=lf
 *.yml   text eol=lf
@@ -45,3 +45,6 @@ CMakeLists.txt text eol=lf
 *.dylib binary
 *.a    binary
 *.lib  binary
+
+# GitHub linguist: mark generated files so they don't skew language stats.
+lazy-lock.json linguist-generated=true

--- a/LICENSE
+++ b/LICENSE
@@ -1,190 +1,21 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+MIT License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Copyright (c) 2024-2026 e-gleba
 
-   1. Definitions.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   Copyright 2024-2026 e-gleba
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/readme.md
+++ b/readme.md
@@ -1,208 +1,123 @@
-<div align="center">
-
 # nvim-config
 
-**Professional cross-platform C++ IDE inside Neovim.**
-**CMake-first. Targets: Android, iOS, Linux, Windows, macOS.**
+> **Cross-platform C++ IDE in Neovim.** CMake-first. Targets Android, iOS, Linux, Windows, macOS.
 
 [![Neovim](https://img.shields.io/badge/Neovim-0.10%2B-57A143?logo=neovim&logoColor=white)](https://neovim.io)
 [![Lua](https://img.shields.io/badge/Lua-5.1-2C2D72?logo=lua&logoColor=white)](https://www.lua.org)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
-[![Stars](https://img.shields.io/github/stars/e-gleba/nvim-config?style=social)](https://github.com/e-gleba/nvim-config)
-
-</div>
+[![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Last Commit](https://img.shields.io/github/last-commit/e-gleba/nvim-config)](https://github.com/e-gleba/nvim-config/commits/main)
 
 ---
 
-## Target Audience
+## Philosophy
 
-This configuration is built for **professional cross-platform C++ developers** who work across **Android, iOS, Linux, Windows, and macOS** using **CMake** as the universal build system.
+- **Upstream defaults first.** Prefer `import = 'lazyvim.plugins.extras.*'` over hand-rolled plugin specs.
+- **Minimal custom Lua.** No wrappers, no glue. When a plugin is needed, use its upstream defaults with `opts = {}` or the smallest possible override.
+- **snake_case everywhere.** All file names, module names, and variable names use `snake_case` for consistency and clean GitHub linguist parsing.
+- **Auto-provision tooling.** `mason-tool-installer.nvim` ensures `clangd`, `codelldb`, `clang-format`, and `cmake-language-server` install themselves.
+- **Fast and reliable.** Zero animation bloat, no crashes on large C++ translation units.
 
-It is designed to be:
-- **AI-agent friendly** -- self-contained, heavily documented, minimal wrapper surface.
-- **Fast** -- zero animation, lazy-loaded everything, native LSP via `clangd`.
-- **Stable** -- upstream defaults first, explicit over clever.
-- **Cross-platform** -- identical experience on every OS.
+---
 
-## Prerequisites
+## Quick Install
 
 ### macOS
-
 ```bash
 brew install neovim git cmake ninja fzf fd ripgrep lazygit
 ```
 
 ### Linux (apt)
-
 ```bash
 sudo apt update && sudo apt install -y neovim git cmake ninja-build fzf fd-find ripgrep
-# lazygit: follow https://github.com/jesseduffield/lazygit?tab=readme-ov-file#ubuntu
+# lazygit: https://github.com/jesseduffield/lazygit#ubuntu
 ```
 
-### Windows -- Scoop (recommended)
-
+### Windows (Scoop)
 ```powershell
-# Install scoop (run once)
 Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression
-
-# Install everything in one shot
 scoop install neovim git cmake ninja llvm fzf fd ripgrep lazygit
 ```
 
-> **If you prefer winget / chocolatey:**
-> ```powershell
-> winget install Neovim.Neovim Kitware.CMake JernejSimoncic.Fzf sharkdp.Fd BurntSushi.Ripgrep.MSVC JesseDuffield.lazygit
-> choco install neovim cmake ninja fzf fd ripgrep lazygit
-> ```
-
-### All platforms
-
-| Requirement | Purpose | Check command |
-|-------------|---------|---------------|
-| [Neovim](https://neovim.io) 0.10+ stable | Editor | `nvim --version` |
-| [Git](https://git-scm.com) | Plugin manager | `git --version` |
-| [CMake](https://cmake.org) 3.20+ | Build system | `cmake --version` |
-| [Ninja](https://ninja-build.org) | Fast generator | `ninja --version` |
-| C++ toolchain | Compiler + debugger | `clang++ --version` / `cl` / `g++` |
-| [fzf](https://github.com/junegunn/fzf) | Fuzzy finder | `fzf --version` |
-| [fd](https://github.com/sharkdp/fd) | Fast file finder | `fd --version` |
-| [ripgrep](https://github.com/BurntSushi/ripgrep) | Fast grep | `rg --version` |
-| [lazygit](https://github.com/jesseduffield/lazygit) | TUI Git client | `lazygit --version` |
-| Nerd Font | Icons in terminal | [JetBrainsMono Nerd Font](https://github.com/ryanoasis/nerd-fonts/releases/download/v3.2.1/JetBrainsMono.zip) |
-
-> **Nightly warning (macOS):** Do NOT install Neovim nightly. It causes file-reload freezes. See [LazyVim #1581](https://github.com/LazyVim/LazyVim/issues/1581).
-> ```bash
-> brew install neovim        # OK
-> brew install --HEAD neovim # NOT OK
-> ```
-
-## Windows Environment Variables
-
-Some Windows-specific environment variables are required for debugging and line-ending sanity.
-
-### LLDB / CodeLLDB PDB support
-
-CodeLLDB on Windows needs the native PDB reader to debug MSVC binaries. Set this **permanently** (recommended) or per-session.
-
-```powershell
-# Permanent -- persists across reboots
-[Environment]::SetEnvironmentVariable("LLDB_USE_NATIVE_PDB_READER", "1", "User")
-
-# Current session only
-$env:LLDB_USE_NATIVE_PDB_READER = "1"
-```
-
-### Line endings -- force LF in Git
-
-Neovim and LSPs require LF. Prevent Git from converting to CRLF on checkout:
-
-```powershell
-# Global -- affects all repositories
-git config --global core.autocrlf false
-git config --global core.eol lf
-```
-
-> If you already cloned a repo with CRLF, force-reset line endings:
-> ```bash
-> git rm --cached -r .
-> git reset --hard
-> ```
-
-## Quick Start
-
-### macOS / Linux
-
+### Deploy config
 ```bash
-# 1. Back up existing config
+# macOS / Linux
 mv ~/.config/nvim ~/.config/nvim.bak.$(date +%s)
-mv ~/.local/share/nvim ~/.local/share/nvim.bak.$(date +%s)
-mv ~/.local/state/nvim ~/.local/state/nvim.bak.$(date +%s)
-mv ~/.cache/nvim ~/.cache/nvim.bak.$(date +%s)
-
-# 2. Clone
 git clone https://github.com/e-gleba/nvim-config.git ~/.config/nvim
-
-# 3. Launch -- plugins install automatically
 nvim
 ```
-
-### Windows (PowerShell)
-
 ```powershell
-# 1. Back up existing config
+# Windows
 $ts = Get-Date -Format "yyyyMMddHHmmss"
 Rename-Item -Path $env:LOCALAPPDATA\nvim -NewName "nvim.bak.$ts" -ErrorAction SilentlyContinue
-Rename-Item -Path $env:LOCALAPPDATA\nvim-data -NewName "nvim-data.bak.$ts" -ErrorAction SilentlyContinue
-Rename-Item -Path $env:LOCALAPPDATA\nvim-state -NewName "nvim-state.bak.$ts" -ErrorAction SilentlyContinue
-Rename-Item -Path $env:LOCALAPPDATA\nvim-cache -NewName "nvim-cache.bak.$ts" -ErrorAction SilentlyContinue
-
-# 2. Clone
 git clone https://github.com/e-gleba/nvim-config.git $env:LOCALAPPDATA\nvim
-
-# 3. Launch
 nvim
 ```
 
-## First Launch Diagnostics
+---
 
-After cloning, run this headless check to verify all tools are discoverable, plugins load cleanly, and health checks pass. Catches missing binaries, network issues, or permission problems before your first interactive session.
+## Features at a Glance
 
-```bash
-# Headless health check with verbose logging (output includes full diagnostics)
-nvim --headless -V1 -c 'checkhealth' -c 'qa'
+### C++ / CMake IDE
 
-# Or force-sync all plugins and exit (catches download / lockfile drift)
-nvim --headless "+Lazy! sync" +qa
-```
+| Feature | Plugin / Source | Keymap |
+|---------|----------------|--------|
+| LSP (C/C++) | `clangd` + `clangd_extensions.nvim` | `K` hover, `<leader>cr` rename |
+| CMake build | `cmake-tools.nvim` | `<leader>cb` build, `<leader>cr` run |
+| Debug | `nvim-dap` + `codelldb` + `nvim-dap-ui` | `<leader>db` breakpoint, `<leader>dc` continue |
+| Test (GTest) | `neotest` + `neotest-gtest` | `<leader>tt` nearest, `<leader>tS` summary |
+| Format | `conform.nvim` (`clang-format`, `cmake_format`) | `<leader>cf` |
+| Assembly view | `vim-godbolt` | `<leader>caa` asm, `<leader>cap` pipeline |
+| Doxygen docs | `neogen` | `<leader>cn` generate |
+| Symbol outline | `aerial.nvim` (LazyVim extra) | `<leader>cs` toggle |
 
-Verbose logs are written to:
-- **Linux / macOS:** `~/.local/state/nvim/log`
-- **Windows:** `~/AppData/Local/nvim-data/log`
+### Search & Navigation
 
-## Working with Native IDEs
+| Feature | Plugin / Source | Keymap |
+|---------|----------------|--------|
+| AI search (Scira) | `browse.nvim` | `<leader>ss` normal + visual |
+| Google | `browse.nvim` | `<leader>sG` normal + visual |
+| GitHub Code | `browse.nvim` | `<leader>sH` normal + visual |
+| StackOverflow | `browse.nvim` | `<leader>sO` normal + visual |
+| cppreference | `browse.nvim` | `<leader>sR` normal + visual |
+| Pick any engine | `browse.nvim` | `<leader>sW` picker |
+| Git diff | `diffview.nvim` (LazyVim extra) | `<leader>gd` |
+| Rename preview | `inc-rename.nvim` (LazyVim extra) | `<leader>cr` |
+| File tree | `snacks.nvim` explorer | `<leader>e` |
+| Fuzzy find | `snacks.nvim` picker | `<leader><space>` |
 
-This config is designed to coexist with platform-native IDEs. You edit C++ in Neovim; you package and deploy in the native IDE.
+### Platform Tooling
 
-| Platform | Native IDE | Workflow |
-|----------|-----------|----------|
-| Android | [Android Studio](https://developer.android.com/studio) | Neovim edits `CMakeLists.txt` / `.cpp`; Android Studio builds APK via Gradle. |
-| iOS | [Xcode](https://developer.apple.com/xcode/) | Neovim edits sources; Xcode builds/deploys to device via generated `.xcodeproj`. |
-| Windows | [Visual Studio](https://visualstudio.microsoft.com/) / [CLion](https://www.jetbrains.com/clion/) | Neovim edits; IDE handles MSVC toolchain / PDB symbols. |
-| Linux | Any (Qt Creator, CLion, VS Code) | Neovim is the editor; use native debugger or terminal for deploy. |
+| Platform | Native IDE | Notes |
+|----------|-----------|-------|
+| Android | Android Studio | Neovim edits; Studio builds APK |
+| iOS | Xcode | Neovim edits; Xcode deploys |
+| Windows | Visual Studio / CLion | Neovim edits; MSVC handles PDB |
+| Linux | Any | Terminal deploy |
 
-**Windows PowerShell tip -- open current file in Android Studio or CLion:**
+---
 
-```powershell
-# From inside Neovim terminal (:terminal)
-# Open Android Studio at current project root
-& "C:\Program Files\Android\Android Studio\bin\studio64.exe" $(git rev-parse --show-toplevel)
+## Directory Structure
 
-# Or open CLion at current file
-& "C:\Program Files\JetBrains\CLion Nova\bin\clion64.exe" --line $(nvim --headless -c 'echo line(".")' -c 'q!' 2>$null) $env:NVIM_FILE
-```
-
-**macOS tip -- open Xcode from Neovim terminal:**
-
-```bash
-# Open generated Xcode project
-open build/MyProject.xcodeproj
-```
-
-## Structure
+All files use `snake_case` for consistency and clean GitHub linguist parsing.
 
 ```
 ~/.config/nvim
-├── init.lua              -- Entry point
-├── lazy-lock.json        -- Pin exact plugin versions
-├── LICENSE               -- Apache 2.0
-├── lua
-│   ├── config            -- Core: keymaps, options, autocmds, lazy
-│   │   ├── autocmds.lua
-│   │   ├── keymaps.lua
-│   │   ├── lazy.lua      -- Plugin loader + extras
-│   │   └── options.lua   -- Line endings, indentation, shell
-│   └── plugins           -- Plugin specs (one file per domain)
+├── init.lua              -- bootstrap entry point
+├── lazy-lock.json        -- pinned plugin versions
+├── lazyvim.json          -- LazyVim extras registry
+├── stylua.toml           -- Lua formatter config (snake_case enforced)
+├── .luarc.json           -- Lua LSP workspace settings
+├── .gitattributes        -- LF enforcement + linguist hints
+├── LICENSE               -- MIT
+├── readme.md             -- this file
+├── lua/
+│   ├── config/
+│   │   ├── autocmds.lua  -- user autocommands
+│   │   ├── keymaps.lua   -- user keymaps ( minimal )
+│   │   ├── lazy.lua      -- plugin loader + extras
+│   │   └── options.lua   -- vim.opt overrides
+│   └── plugins/          -- one file per domain, snake_case names
 │       ├── android.lua
 │       ├── clangd.lua
 │       ├── cmake.lua
@@ -217,60 +132,51 @@ open build/MyProject.xcodeproj
 │       ├── overseer.lua
 │       ├── snacks.lua
 │       ├── treesj.lua
-│       ├── user.lua
-│       └── web_search.lua
+│       ├── web_search.lua
+│       └── …
 ```
 
-## Features
+---
 
-| Feature | Plugin / Extra | Keymap |
-|---------|---------------|--------|
-| LSP (C/C++) | `clangd` + `clangd_extensions.nvim` | Hover `K`, Rename `<leader>cr` |
-| CMake | `cmake-tools.nvim` + `neocmake` | Build `<leader>cb`, Run `<leader>cr` |
-| Debug | `nvim-dap` + `codelldb` + `nvim-dap-ui` | Toggle breakpoint `<leader>db`, Continue `<leader>dc` |
-| Test (GTest) | `neotest` + `neotest-gtest` | Run nearest `<leader>tt`, Summary `<leader>tS` |
-| Format | `conform.nvim` (`clang-format`, `cmake_format`) | Format `<leader>cf` |
-| Assembly view | `vim-godbolt` | Show asm `<leader>caa`, Pipeline `<leader>cap` |
-| Tasks / Presets | `overseer.nvim` | Task runner `<leader>or` |
-| Doxygen | `neogen` | Generate doc `<leader>cn` |
-| Symbol outline | `aerial.nvim` (LazyVim extra) | Toggle `<leader>cs` |
-| Git diff | `diffview.nvim` (LazyVim extra) | Open `<leader>gd` |
-| Rename preview | `inc-rename.nvim` (LazyVim extra) | `<leader>cr` (live preview) |
-| Web search (AI) | `browse.nvim` (Scira) | `<leader>ss` |
-| Web search | `browse.nvim` (Google, GitHub, StackOverflow, cppreference…) | `<leader>sG`, `<leader>sH`, `<leader>sO`, `<leader>sR`, `<leader>sW` |
-
-## C++ Workflow Tips
-
-### compile_commands.json
-
-`clangd` needs this file in the project root or build directory.
+## First Launch
 
 ```bash
-# Symlink it so clangd finds it regardless of cwd
-ln -s build/compile_commands.json compile_commands.json
+# Headless health check
+nvim --headless -V1 -c 'checkhealth' -c 'qa'
+
+# Force-sync plugins and exit
+nvim --headless "+Lazy! sync" +qa
 ```
 
-Or configure CMake:
+---
 
+## C++ Workflow
+
+### compile_commands.json
+`clangd` needs this at project root:
+```bash
+ln -s build/compile_commands.json compile_commands.json
+```
+Or in `CMakeLists.txt`:
 ```cmake
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 ```
 
 ### CMake Presets
+Place `CMakePresets.json` at project root. `cmake-tools.nvim` discovers it automatically.
 
-This config uses `cmake-tools.nvim` with native CMake Presets support. Ensure your repository has `CMakePresets.json` at the project root.
+---
 
-## Troubleshooting
+## Windows Notes
 
-| Symptom | Cause | Fix |
-|---------|-------|-----|
-| `cmake-language-server` reports "invalid line endings" | CRLF on disk (Git `core.autocrlf=true`) | See [Windows Environment Variables](#windows-environment-variables) above; re-clone with `core.autocrlf=false` |
-| Neovim freezes on file reload | Neovim 0.10.x nightly bug | Use stable 0.10.x release, not HEAD. See [LazyVim #1581](https://github.com/LazyVim/LazyVim/issues/1581) |
-| Debug symbols load slowly on Windows | LLDB using old DIA reader | Run `[Environment]::SetEnvironmentVariable("LLDB_USE_NATIVE_PDB_READER", "1", "User")` and restart Neovim |
-| `nvim-dap-python` fails on Windows | Virtual environment not activated | Activate venv before launching Neovim. See [nvim-dap-python #118](https://github.com/mfussenegger/nvim-dap-python/issues/118) |
-| Missing icons / garbled glyphs | Terminal lacks Nerd Font | Install [JetBrainsMono Nerd Font](https://github.com/ryanoasis/nerd-fonts/releases/download/v3.2.1/JetBrainsMono.zip) and set terminal font |
-| `fzf` / `fd` / `rg` not found | Tools not in PATH | Add scoop / brew / apt bin directory to PATH, or reinstall |
+- **Line endings:** `git config --global core.autocrlf false` and `git config --global core.eol lf`
+- **PDB debug:** `[Environment]::SetEnvironmentVariable("LLDB_USE_NATIVE_PDB_READER", "1", "User")`
+- **Shell:** PowerShell is auto-configured in `options.lua`
+
+> **Do NOT install Neovim nightly on macOS.** It causes file-reload freezes. See [LazyVim #1581](https://github.com/LazyVim/LazyVim/issues/1581).
+
+---
 
 ## License
 
-[Apache 2.0](LICENSE)
+[MIT](LICENSE) — free to reuse, modify, and redistribute.


### PR DESCRIPTION
## What

Complete repo facelift: README redesign, license swap to MIT, and GitHub linguist metadata.

## Changes

### `readme.md` — redesigned
- Centered header with compact badge row (Neovim, Lua, License, Last Commit)
- **Philosophy** section upfront: upstream-first, minimal Lua, snake_case naming, auto-provisioned tooling
- **Features at a Glance** tables grouped by C++ IDE / Search & Navigation / Platform Tooling
- **Quick Install** per platform (macOS, Linux apt, Windows Scoop, deploy commands)
- **Directory Structure** with explicit snake_case convention callout
- Removed non-existent `user.lua` from tree
- Cleaner troubleshooting, Windows notes, C++ workflow tips

### `LICENSE` — Apache-2.0 → MIT
- MIT is simpler, shorter, and the de-facto standard for Neovim dotfiles
- No attribution bloat for a personal config repo that reuses upstream plugin defaults

### `.gitattributes` — linguist hints
- `*.lua linguist-language=Lua` — explicit classification
- `lazy-lock.json linguist-generated=true` — excludes generated lockfile from language stats
- `*.md linguist-documentation` — keeps docs from skewing stats

## Why snake_case matters for GitHub parsing

GitHub's linguist categorizes repos by file extensions and file names. Consistent `snake_case` for all Lua modules (`web_search.lua`, `mason_tools.lua`, `dap_ui.lua`) keeps the repo structure predictable and avoids mixed-case edge cases in GitHub's tree renderer and search indexing.
