### PR TITLE
feat(jira): corporate Jira with zero-auth commit prefix + optional board

### DIFF
--- a/lua/config/autocmds.lua
+++ b/lua/config/autocmds.lua
@@ -6,3 +6,32 @@
 --
 -- Or remove existing autocmds by their group name (which is prefixed with `lazyvim_` for the defaults)
 -- e.g. vim.api.nvim_del_augroup_by_name("lazyvim_wrap_spell")
+
+-- Jira commit prefix: extract issue key (e.g. PROJ-123) from the current
+-- git branch and prepend it to the commit message buffer. Zero auth, zero
+-- API calls — works offline and on any repo that uses Jira-style branch names.
+-- Supports patterns like: feature/PROJ-123-description, PROJ-123-fix-bug, etc.
+vim.api.nvim_create_autocmd('FileType', {
+    pattern = 'gitcommit',
+    callback = function()
+        local branch = vim.fn.trim(vim.fn.system({ 'git', 'branch', '--show-current' }))
+        if vim.v.shell_error ~= 0 then
+            return
+        end
+
+        local key = branch:match('([A-Z][A-Z0-9]*%-%d+)')
+        if not key then
+            return
+        end
+
+        local buf = vim.api.nvim_get_current_buf()
+        local line = vim.api.nvim_buf_get_lines(buf, 0, 1, false)[1] or ''
+
+        -- Only inject if the first line is empty (not an amend or reword).
+        if line:match('^%s*$') then
+            local prefix = key .. ': '
+            vim.api.nvim_buf_set_lines(buf, 0, 1, false, { prefix })
+            vim.api.nvim_win_set_cursor(0, { 1, #prefix })
+        end
+    end,
+})

--- a/lua/plugins/jira.lua
+++ b/lua/plugins/jira.lua
@@ -1,0 +1,25 @@
+-- Optional Jira integration via letieu/jira.nvim.
+-- Loads only if JIRA_DOMAIN env var is set so it stays invisible for users
+-- without corporate Jira access.
+--
+-- To activate:
+--   export JIRA_DOMAIN=yourcompany.atlassian.net
+--   export JIRA_USER=your-email@company.com
+--   export JIRA_API_TOKEN=your-api-token
+-- Then run :Jira auth login inside Neovim.
+--
+-- Ref: https://github.com/letieu/jira.nvim
+return {
+    {
+        'letieu/jira.nvim',
+        cond = function()
+            return vim.env.JIRA_DOMAIN ~= nil
+        end,
+        dependencies = { 'nvim-telescope/telescope.nvim' },
+        opts = {},
+        keys = {
+            { '<leader>jj', '<cmd>Jira<cr>', desc = 'Jira board', mode = 'n' },
+            { '<leader>ji', '<cmd>Jira info<cr>', desc = 'Jira issue info', mode = 'n' },
+        },
+    },
+}

--- a/readme.md
+++ b/readme.md
@@ -74,6 +74,7 @@ nvim --headless "+Lazy! sync" +qa                # force sync
         ├── dap_ui.lua
         ├── format.lua
         ├── godbolt.lua
+        ├── jira.lua
         ├── mason_tools.lua
         ├── neogen.lua
         ├── neotest.lua
@@ -100,6 +101,32 @@ nvim --headless "+Lazy! sync" +qa                # force sync
 | StackOverflow | `<leader>sO` |
 | cppreference | `<leader>sR` |
 | Web search picker | `<leader>sW` |
+| Jira board (if configured) | `<leader>jj` |
+| Jira issue info (if configured) | `<leader>ji` |
+
+## Jira workflow
+
+### Zero-auth commit prefix (always active)
+
+On `git commit`, if your branch name contains a Jira-style key (e.g. `feature/PROJ-123-fix`), the commit buffer is auto-prepended with `PROJ-123: `. Cursor lands right after the colon — no auth, no API, works offline.
+
+### Full Jira integration (optional, requires auth)
+
+Set env vars to activate the plugin:
+```bash
+export JIRA_DOMAIN=yourcompany.atlassian.net
+export JIRA_USER=your-email@company.com
+export JIRA_API_TOKEN=your-api-token
+```
+
+Then inside Neovim:
+```vim
+:Jira auth login
+:Jira <PROJECT_KEY>          -- open board
+:Jira info <ISSUE_KEY>       -- view issue
+```
+
+Plugin only loads when `JIRA_DOMAIN` is present; otherwise it stays invisible.
 
 ## C++ workflow
 


### PR DESCRIPTION
## What

Two-tier Jira integration: zero-auth commit prefixes for everyone, optional full board/issue view for users with API access.

## Zero-auth commit prefix (always active)

When you open a `git commit` buffer and your branch contains a Jira-style key, the buffer auto-prepends it:

```
branch:  feature/PROJ-123-fix-memory-leak
commit:  PROJ-123: <cursor here>
```

- Extracts pattern `[A-Z][A-Z0-9]*-\d+` from `git branch --show-current`
- Works offline, no API token, no corporate VPN needed
- Only injects on empty first line (respects `git commit --amend`)

## Optional full Jira integration (auth required)

Plugin: `letieu/jira.nvim` — 230+ stars, v0.8.2, actively maintained.

- Conditionally loaded **only** when `JIRA_DOMAIN` env var is set
- Completely invisible if you don't set the env var
- `:Jira auth login` → `:Jira <PROJECT_KEY>` for board view

| Keymap | Action |
|--------|--------|
| `<leader>jj` | Open Jira board |
| `<leader>ji` | View issue info |

## Why two-tier

Corporate Jira is behind auth walls, but every team still wants `PROJ-123: ` in commit messages. The prefix feature works for every dev on every repo; the board plugin is opt-in via env vars.

## Files changed

| File | Change |
|------|--------|
| `lua/config/autocmds.lua` | Add `FileType gitcommit` autocmd |
| `lua/plugins/jira.lua` | New — optional `letieu/jira.nvim` spec |
| `readme.md` | Jira workflow section, keymaps, directory tree |
