### PR TITLE
fix(docker): use upstream official lazygit install for Ubuntu 24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,17 @@ RUN apt-get update \
         fzf \
         fd-find \
         ripgrep \
-        lazygit \
         unzip \
     && ln -sf $(which fdfind) /usr/local/bin/fd \
     && rm -rf /var/lib/apt/lists/*
+
+# lazygit — Ubuntu 24.04 does not ship this in apt; use upstream official install
+RUN LAZYGIT_VERSION=$(curl -s "https://api.github.com/repos/jesseduffield/lazygit/releases/latest" | grep -Po '"tag_name": *"v\K[^"]*') \
+    && LAZYGIT_ARCH=$(uname -m | sed -e 's/aarch64/arm64/') \
+    && curl -fsSL "https://github.com/jesseduffield/lazygit/releases/download/v${LAZYGIT_VERSION}/lazygit_${LAZYGIT_VERSION}_Linux_${LAZYGIT_ARCH}.tar.gz" -o /tmp/lazygit.tar.gz \
+    && tar xf /tmp/lazygit.tar.gz -C /tmp lazygit \
+    && install /tmp/lazygit -D -t /usr/local/bin/ \
+    && rm /tmp/lazygit /tmp/lazygit.tar.gz
 
 # Neovim stable
 RUN curl -fsSL https://github.com/neovim/neovim/releases/download/stable/nvim-linux-x86_64.tar.gz \


### PR DESCRIPTION
## Why it failed again

`apt install lazygit` on `ubuntu:24.04` → exit code 100 because the `lazygit` package **does not exist** in Ubuntu 24.04 (Noble) repositories. It was added in Ubuntu 25.10+ [text](https://github.com/jesseduffield/lazygit#debian-and-ubuntu).

## Fix

Replaced `apt install lazygit` with the **official upstream install method** documented by jesseduffield/lazygit for Debian 12 / Ubuntu 25.04 and earlier:

1. Query GitHub API for latest release tag
2. Download the architecture-matching versioned tarball
3. Extract binary to `/usr/local/bin`

This is the exact method lazygit's own README recommends, not a brittle `latest/download` redirect.

## What the lint workflow does (no, it does NOT push)

| Workflow | Builds image? | Pushes to registry? | What it actually does |
|----------|-------------|---------------------|----------------------|
| `ci.yml` (lint) | Yes, locally | **No** | Builds image with `load: true`, runs `stylua --check` inside it, then discards |
| `docker.yml` (publish) | Yes | **Yes**, to `ghcr.io` | Only on `Dockerfile` or `.github/workflows/docker.yml` changes + manual trigger |

So `ci.yml` never pushes anything. It only builds locally so `stylua` can lint your Lua in a controlled environment.