### PR TITLE
fix(ci): use published Docker image for lint, reusable publish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,6 @@ on:
       - '*.toml'
       - '*.json'
       - 'lazy-lock.json'
-      - 'Dockerfile'
-      - '.github/workflows/ci.yml'
   pull_request:
     paths:
       - 'lua/**'
@@ -18,12 +16,9 @@ on:
       - '*.toml'
       - '*.json'
       - 'lazy-lock.json'
-      - 'Dockerfile'
-      - '.github/workflows/ci.yml'
 
 permissions:
   contents: read
-  packages: read
 
 jobs:
   lint:
@@ -31,28 +26,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: docker/setup-buildx-action@v3
+      - name: Ensure CI image
+        run: |
+          IMAGE="ghcr.io/${{ github.repository }}/nvim-ci:latest"
+          if docker pull "$IMAGE" 2>/dev/null; then
+            echo "Pulled $IMAGE"
+          else
+            echo "Registry image not found; building locally..."
+            docker build -t "$IMAGE" .
+          fi
 
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: false
-          load: true
-          tags: nvim-ci:local
-          cache-from: |
-            type=gha
-            type=registry,ref=ghcr.io/${{ github.repository }}/nvim-ci:latest
-          cache-to: type=gha,mode=max
-
-      - run: |
+      - name: Run stylua
+        run: |
           docker run --rm \
-            --entrypoint stylua \
-            -v ${{ github.workspace }}:/workspace \
-            nvim-ci:local \
-            --check /workspace
+            -v "${{ github.workspace }}:/workspace" \
+            ghcr.io/${{ github.repository }}/nvim-ci:latest \
+            stylua --check /workspace

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,12 +1,24 @@
 name: publish-docker
 
 on:
+  workflow_call:
+    inputs:
+      tag:
+        required: false
+        type: string
+        default: latest
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag'
+        required: false
+        default: 'latest'
+        type: string
   push:
     branches: [main]
     paths:
       - 'Dockerfile'
       - '.github/workflows/publish-docker.yml'
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -30,12 +42,21 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Determine tag
+        id: tag
+        run: |
+          TAG="${{ inputs.tag }}"
+          if [ -z "$TAG" ]; then
+            TAG="latest"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
       - uses: docker/metadata-action@v5
         id: meta
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ steps.tag.outputs.tag }},enable=true
 
       - uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,3 +36,12 @@ jobs:
           gh release create ${{ inputs.version }} \
             --generate-notes \
             --title "${{ inputs.version }}"
+
+  publish-docker:
+    needs: release
+    uses: ./.github/workflows/publish-docker.yml
+    with:
+      tag: ${{ inputs.version }}
+    permissions:
+      contents: read
+      packages: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,4 @@ RUN curl -fsSL https://github.com/JohnnyMorganz/StyLua/releases/download/v2.0.2/
     && rm /tmp/stylua.zip
 
 WORKDIR /workspace
-ENTRYPOINT ["nvim"]
+CMD ["nvim"]

--- a/readme.md
+++ b/readme.md
@@ -58,17 +58,14 @@ nvim --headless "+Lazy! sync" +qa                # force sync
 
 ## CI & Release
 
-### Lint
-Runs `stylua --check` inside a container on every Lua change. Uses registry cache — does not rebuild from scratch.
+| Workflow | Trigger | Result |
+|----------|---------|--------|
+| **Lint** | Push / PR on `lua/**`, `init.lua`, lockfiles | Pulls `ghcr.io/.../nvim-ci:latest` and runs `stylua --check`. Falls back to local build if image is absent. |
+| **Publish Docker** | Manual dispatch, or push to `main` with `Dockerfile` changes | Builds and pushes `ghcr.io/.../nvim-ci:latest`. |
+| **Release** | Manual dispatch with version tag | Creates GitHub Release with auto-generated notes, then builds and pushes a tagged Docker image (`v1.2.3`). |
 
-### Publish Docker
-Manually trigger via [Actions → publish-docker](https://github.com/e-gleba/nvim-config/actions/workflows/publish-docker.yml) or push to `main` with `Dockerfile` changes.
-
-### Release
-1. Go to [Actions → release](https://github.com/e-gleba/nvim-config/actions/workflows/release.yml).
-2. Click **Run workflow**.
-3. Enter version (`v1.2.3`).
-4. Workflow creates the tag and auto-generates release notes from merged PRs.
+- [Run publish-docker](https://github.com/e-gleba/nvim-config/actions/workflows/publish-docker.yml)
+- [Run release](https://github.com/e-gleba/nvim-config/actions/workflows/release.yml)
 
 ## Structure
 


### PR DESCRIPTION
- **Dockerfile** — `ENTRYPOINT ["nvim"]` → `CMD ["nvim"]` so `docker run image stylua ...` works naturally without `--entrypoint` overrides [text](https://github.com/e-gleba/nvim-config/blob/858e11d1874ddebc1d20267ed933cd5f02bac19a/Dockerfile)
- **ci.yml** — pulls `ghcr.io/.../nvim-ci:latest` from registry. Falls back to local `docker build` only if the image is absent (first run). Triggers restricted to `lua/**`, `init.lua`, `*.toml`, `*.json`, `lazy-lock.json` — no wasted runs on readme or workflow edits [text](https://github.com/e-gleba/nvim-config/blob/858e11d1874ddebc1d20267ed933cd5f02bac19a/.github/workflows/ci.yml)
- **publish-docker.yml** — added `workflow_call` trigger so release workflow can reuse it. Tag input supports `latest` (default) or explicit tags like `v1.2.3` [text](https://github.com/e-gleba/nvim-config/blob/858e11d1874ddebc1d20267ed933cd5f02bac19a/.github/workflows/publish-docker.yml)
- **release.yml** — after creating the GitHub Release, calls `publish-docker.yml` with the release version tag [text](https://github.com/e-gleba/nvim-config/blob/858e11d1874ddebc1d20267ed933cd5f02bac19a/.github/workflows/release.yml)
- **readme.md** — CI & Release section now shows a workflow table with direct trigger links [text](https://github.com/e-gleba/nvim-config/blob/858e11d1874ddebc1d20267ed933cd5f02bac19a/readme.md)