### PR TITLE
ci: bump all actions to latest stable, remove custom fallback logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,22 +19,19 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Ensure CI image
-        run: |
-          IMAGE="ghcr.io/${{ github.repository }}/nvim-ci:latest"
-          if docker pull "$IMAGE" 2>/dev/null; then
-            echo "Pulled $IMAGE"
-          else
-            echo "Registry image not found; building locally..."
-            docker build -t "$IMAGE" .
-          fi
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run stylua
         run: |

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -32,33 +32,24 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Determine tag
-        id: tag
-        run: |
-          TAG="${{ inputs.tag }}"
-          if [ -z "$TAG" ]; then
-            TAG="latest"
-          fi
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-
-      - uses: docker/metadata-action@v5
+      - uses: docker/metadata-action@v6
         id: meta
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=${{ steps.tag.outputs.tag }},enable=true
+            type=raw,value=${{ inputs.tag || 'latest' }}
 
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
- actions/checkout v4 → v6
- docker/setup-buildx-action v3 → v4 (Node 24 native)
- docker/login-action v3 → v4
- docker/metadata-action v5 → v6 (Node 24 native)
- docker/build-push-action v5 → v7
- ci.yml: use docker/login-action for GHCR auth instead of manual docker commands; drop local image-build fallback
- publish-docker.yml: drop Determine tag step, use `inputs.tag || 'latest'` inline
- release.yml: checkout v4 → v6